### PR TITLE
Remove Node 20 deprecation warnings from CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12.3'
 
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm


### PR DESCRIPTION
## Background
- The CI workflow passed, but GitHub Actions runner annotations warned that `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/setup-python@v5` still depended on the deprecated Node.js 20 action runtime.
- This slice upgrades the GitHub-maintained `uses:` actions to Node24-capable majors. It does not change the frontend job's application runtime target, which remains `node-version: 22`.

## Changes
- Upgrade `actions/checkout` from `v4` to `v6` in both jobs.
- Upgrade `actions/setup-node` from `v4` to `v6` in the frontend job.
- Upgrade `actions/setup-python` from `v5` to `v6` in the backend job.

## Validation
- `npm --prefix frontend run lint`
- `poetry run ruff check .`
- `poetry run pytest`
- `npm --prefix frontend run build`
- Push CI on `fix/4-upgrade-ci-actions-for-node-24-runner-compatibility` passed without the previous Node.js 20 deprecation annotations.

## Impact
- Removes the current Node.js 20 deprecation noise from the repository CI workflow.
- Keeps the existing project toolchain targets unchanged while moving the GitHub-hosted action runtime surface onto Node24-capable majors.

## Linked issue
Closes #4