### PR TITLE
[Bug] Add Korean language support to dashboard UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,15 @@ import { useProducePrices } from './hooks/useProducePrices';
 import { useRtrProfiles } from './hooks/useRtrProfiles';
 import { useWeatherOutlook } from './hooks/useWeatherOutlook';
 import type { CropType } from './types';
-import { DASHBOARD_SENSOR_COPY, IDEAL_RANGES, UNIT_LABELS } from './utils/displayCopy';
+import type { AppLocale } from './i18n/locale';
+import { useLocale } from './i18n/LocaleProvider';
+import {
+  getCropLabel,
+  getDashboardSensorCopy,
+  getDevelopmentStageLabel,
+  getIdealRanges,
+  UNIT_LABELS,
+} from './utils/displayCopy';
 
 const AiAdvisor = lazy(() => import('./components/AiAdvisor'));
 const Charts = lazy(() => import('./components/Charts'));
@@ -23,17 +31,20 @@ const RTROutlookPanel = lazy(() => import('./components/RTROutlookPanel'));
 
 interface LoadingPanelProps {
   title: string;
+  loadingMessage: string;
   minHeightClassName?: string;
   className?: string;
 }
 
 const LoadingPanel = ({
   title,
+  loadingMessage,
   minHeightClassName = 'min-h-[240px]',
   className = '',
 }: LoadingPanelProps) => (
   <div className={`rounded-xl border border-slate-100 bg-white p-6 shadow-sm animate-pulse ${minHeightClassName} ${className}`.trim()}>
     <div className="h-5 w-40 rounded bg-slate-200" />
+    <p className="mt-4 text-sm font-medium text-slate-500">{title}</p>
     <div className="mt-4 space-y-3">
       <div className="h-3 rounded bg-slate-100" />
       <div className="h-3 w-11/12 rounded bg-slate-100" />
@@ -43,7 +54,7 @@ const LoadingPanel = ({
       <div className="h-24 rounded-lg bg-slate-100" />
       <div className="h-24 rounded-lg bg-slate-100" />
     </div>
-    <p className="mt-4 text-xs text-slate-400">{title} module loading...</p>
+    <p className="mt-4 text-xs text-slate-400">{loadingMessage}</p>
   </div>
 );
 
@@ -62,23 +73,96 @@ const AiAdvisorFallback = () => (
 
 interface ChatAssistantFallbackProps {
   onClose: () => void;
+  locale: AppLocale;
 }
 
-const ChatAssistantFallback = ({ onClose }: ChatAssistantFallbackProps) => (
+const CHAT_ASSISTANT_FALLBACK_COPY = {
+  en: {
+    title: 'Assistant',
+    close: 'Close',
+    loading: 'Loading AI assistant...',
+  },
+  ko: {
+    title: '어시스턴트',
+    close: '닫기',
+    loading: 'AI 어시스턴트를 불러오는 중...',
+  },
+} as const;
+
+const APP_COPY = {
+  en: {
+    brandTagline: 'Intelligent Greenhouse Decision Support',
+    systemOnline: 'System Online',
+    askAiAssistant: 'Ask AI Assistant',
+    language: 'Language',
+    advancedModelAnalytics: 'Advanced Model Analytics',
+    yieldForecast: 'Yield Forecast',
+    consultingReport: 'Consulting Report',
+    realTimeEnvironmentalAnalysis: 'Real-time Environmental Analysis',
+    cropStatus: 'Crop Status',
+    growthCycle: 'Growth Cycle',
+    since: 'since',
+    simTime: 'Sim Time',
+    liveProducePrices: 'Live Produce Prices',
+    daeguLiveWeather: 'Daegu Live Weather',
+    rtrStrategy: 'RTR Strategy',
+    advancedModelAnalyticsLoading: 'Advanced Model Analytics module loading...',
+    yieldForecastLoading: 'Yield Forecast module loading...',
+    consultingReportLoading: 'Consulting Report module loading...',
+    realTimeEnvironmentalAnalysisLoading: 'Real-time Environmental Analysis module loading...',
+    liveProducePricesLoading: 'Live Produce Prices module loading...',
+    daeguLiveWeatherLoading: 'Daegu Live Weather module loading...',
+    rtrStrategyLoading: 'RTR Strategy module loading...',
+  },
+  ko: {
+    brandTagline: '스마트 온실 의사결정 지원',
+    systemOnline: '시스템 정상',
+    askAiAssistant: 'AI 어시스턴트',
+    language: '언어',
+    advancedModelAnalytics: '고급 모델 분석',
+    yieldForecast: '수확 전망',
+    consultingReport: '컨설팅 리포트',
+    realTimeEnvironmentalAnalysis: '실시간 환경 분석',
+    cropStatus: '작물 상태',
+    growthCycle: '생육 사이클',
+    since: '시작일',
+    simTime: '시뮬레이션 시각',
+    liveProducePrices: '실시간 농산물 가격',
+    daeguLiveWeather: '대구 실시간 날씨',
+    rtrStrategy: 'RTR 전략',
+    advancedModelAnalyticsLoading: '고급 모델 분석 모듈을 불러오는 중...',
+    yieldForecastLoading: '수확 전망 모듈을 불러오는 중...',
+    consultingReportLoading: '컨설팅 리포트 모듈을 불러오는 중...',
+    realTimeEnvironmentalAnalysisLoading: '실시간 환경 분석 모듈을 불러오는 중...',
+    liveProducePricesLoading: '실시간 농산물 가격 모듈을 불러오는 중...',
+    daeguLiveWeatherLoading: '대구 실시간 날씨 모듈을 불러오는 중...',
+    rtrStrategyLoading: 'RTR 전략 모듈을 불러오는 중...',
+  },
+} as const;
+
+const ChatAssistantFallback = ({ onClose, locale }: ChatAssistantFallbackProps) => {
+  const copy = CHAT_ASSISTANT_FALLBACK_COPY[locale];
+
+  return (
   <div className="fixed bottom-6 right-6 z-50 flex h-[500px] w-96 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl">
     <div className="flex items-center justify-between bg-slate-900 p-4 text-white">
-      <span className="font-medium">Assistant</span>
-      <button onClick={onClose} className="text-slate-300 hover:text-white">Close</button>
+      <span className="font-medium">{copy.title}</span>
+      <button onClick={onClose} className="text-slate-300 hover:text-white">{copy.close}</button>
     </div>
     <div className="flex flex-1 items-center justify-center bg-slate-50 text-sm text-slate-500">
-      Loading AI assistant...
+      {copy.loading}
     </div>
   </div>
-);
+  );
+};
 
 const AUTO_ANALYSIS_INTERVAL_MS = 30 * 60 * 1000;
 
 function App() {
+  const { locale, setLocale } = useLocale();
+  const copy = APP_COPY[locale];
+  const sensorCopy = getDashboardSensorCopy(locale);
+  const idealRanges = getIdealRanges(locale);
   const {
     currentData,
     modelMetrics,
@@ -199,11 +283,29 @@ function App() {
             </div>
             <div>
               <h1 className="text-xl font-bold text-slate-800 tracking-tight">SmartGrow <span className="text-green-600">AI</span></h1>
-              <p className="text-xs text-slate-400 hidden sm:block">Intelligent Greenhouse Decision Support</p>
+              <p className="text-xs text-slate-400 hidden sm:block">{copy.brandTagline}</p>
             </div>
           </div>
 
           <div className="flex items-center gap-4">
+            <div className="hidden items-center gap-2 rounded-lg border border-slate-200 bg-white px-2 py-1 sm:flex">
+              <span className="text-[11px] font-medium uppercase tracking-wide text-slate-400">{copy.language}</span>
+              <div className="flex rounded-md bg-slate-100 p-1">
+                {(['en', 'ko'] as AppLocale[]).map((targetLocale) => (
+                  <button
+                    key={targetLocale}
+                    onClick={() => setLocale(targetLocale)}
+                    className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                      locale === targetLocale
+                        ? 'bg-white text-green-700 shadow-sm'
+                        : 'text-slate-500 hover:text-slate-700'
+                    }`}
+                  >
+                    {targetLocale === 'en' ? 'EN' : '한국어'}
+                  </button>
+                ))}
+              </div>
+            </div>
             {/* Crop Selector */}
             <div className="flex bg-slate-100 p-1 rounded-lg">
               {(['Cucumber', 'Tomato'] as CropType[]).map((crop) => (
@@ -215,21 +317,21 @@ function App() {
                     : 'text-slate-500 hover:text-slate-700'
                     }`}
                 >
-                  {crop}
+                  {getCropLabel(crop, locale)}
                 </button>
               ))}
             </div>
 
             <div className="flex items-center gap-2 text-sm text-slate-500 bg-slate-100 px-3 py-1.5 rounded-full border border-slate-200">
               <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
-              System Online
+              {copy.systemOnline}
             </div>
             <button
               onClick={handleChatToggle}
               className={`flex items-center gap-2 px-4 py-2 rounded-full transition-colors font-medium ${isChatOpen ? 'bg-green-100 text-green-700' : 'bg-slate-800 text-white hover:bg-slate-700'}`}
             >
               <MessageCircle className="w-5 h-5" />
-              <span>Ask AI Assistant</span>
+              <span>{copy.askAiAssistant}</span>
             </button>
           </div>
         </div>
@@ -242,55 +344,55 @@ function App() {
             {/* Sensor Grid */}
             <div className="grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.temperature.title}
+                title={sensorCopy.temperature.title}
                 value={currentData.temperature}
-                unit={DASHBOARD_SENSOR_COPY.temperature.unit}
+                unit={sensorCopy.temperature.unit}
                 icon={Thermometer}
                 color="bg-orange-500"
                 trend={currentData.temperature > 28 ? 'up' : 'stable'}
-                idealRange={IDEAL_RANGES[selectedCrop].temperature}
+                idealRange={idealRanges[selectedCrop].temperature}
               />
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.humidity.title}
+                title={sensorCopy.humidity.title}
                 value={currentData.humidity}
-                unit={DASHBOARD_SENSOR_COPY.humidity.unit}
+                unit={sensorCopy.humidity.unit}
                 icon={Droplets}
                 color="bg-blue-500"
                 trend={currentData.humidity > 80 ? 'up' : 'stable'}
-                idealRange={IDEAL_RANGES[selectedCrop].humidity}
+                idealRange={idealRanges[selectedCrop].humidity}
               />
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.carbonDioxide.title}
+                title={sensorCopy.carbonDioxide.title}
                 value={currentData.co2}
-                unit={DASHBOARD_SENSOR_COPY.carbonDioxide.unit}
+                unit={sensorCopy.carbonDioxide.unit}
                 icon={CloudFog}
                 color="bg-slate-600"
                 trend="stable"
                 idealRange="400-800 ppm"
               />
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.light.title}
+                title={sensorCopy.light.title}
                 value={currentData.light}
-                unit={DASHBOARD_SENSOR_COPY.light.unit}
+                unit={sensorCopy.light.unit}
                 subValue={`~ ${(currentData.light / activeRtrDivider).toFixed(1)} ${UNIT_LABELS.radiativeFlux}`}
                 icon={Sun}
                 color="bg-yellow-500"
                 trend={currentData.light > 1000 ? 'up' : 'down'}
-                idealRange={IDEAL_RANGES[selectedCrop].light}
+                idealRange={idealRanges[selectedCrop].light}
               />
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.vpd.title}
+                title={sensorCopy.vpd.title}
                 value={currentData.vpd}
-                unit={DASHBOARD_SENSOR_COPY.vpd.unit}
+                unit={sensorCopy.vpd.unit}
                 icon={Activity}
                 color="bg-purple-500"
                 trend={currentData.vpd > 1.2 ? 'up' : 'stable'}
-                idealRange={IDEAL_RANGES[selectedCrop].vpd}
+                idealRange={idealRanges[selectedCrop].vpd}
               />
               <SensorCard
-                title={DASHBOARD_SENSOR_COPY.stomatalConductance.title}
+                title={sensorCopy.stomatalConductance.title}
                 value={currentData.stomatalConductance}
-                unit={DASHBOARD_SENSOR_COPY.stomatalConductance.unit}
+                unit={sensorCopy.stomatalConductance.unit}
                 icon={Leaf}
                 color="bg-green-500"
                 trend="stable"
@@ -312,7 +414,7 @@ function App() {
 
           <div className="grid grid-cols-1 items-stretch gap-6 lg:grid-cols-2 xl:grid-cols-[minmax(280px,0.95fr)_minmax(0,1.55fr)_minmax(280px,1fr)]">
             <div className="h-full lg:col-span-2 xl:order-2 xl:col-span-1">
-              <Suspense fallback={<LoadingPanel title="Live Produce Prices" minHeightClassName="min-h-[420px]" className="h-full" />}>
+              <Suspense fallback={<LoadingPanel title={copy.liveProducePrices} loadingMessage={copy.liveProducePricesLoading} minHeightClassName="min-h-[420px]" className="h-full" />}>
                 <ProducePricesPanel
                   prices={producePrices}
                   loading={isProducePricesLoading}
@@ -321,7 +423,7 @@ function App() {
               </Suspense>
             </div>
             <div className="h-full xl:order-1">
-              <Suspense fallback={<LoadingPanel title="Daegu Live Weather" minHeightClassName="min-h-[420px]" className="h-full" />}>
+              <Suspense fallback={<LoadingPanel title={copy.daeguLiveWeather} loadingMessage={copy.daeguLiveWeatherLoading} minHeightClassName="min-h-[420px]" className="h-full" />}>
                 <WeatherOutlookPanel
                   weather={weather}
                   loading={isWeatherLoading}
@@ -330,7 +432,7 @@ function App() {
               </Suspense>
             </div>
             <div className="h-full xl:order-3">
-              <Suspense fallback={<LoadingPanel title="RTR Strategy" minHeightClassName="min-h-[420px]" className="h-full" />}>
+              <Suspense fallback={<LoadingPanel title={copy.rtrStrategy} loadingMessage={copy.rtrStrategyLoading} minHeightClassName="min-h-[420px]" className="h-full" />}>
                 <RTROutlookPanel
                   crop={selectedCrop}
                   currentData={currentData}
@@ -352,9 +454,9 @@ function App() {
         <div className="mb-8">
           <div className="flex items-center gap-2 mb-4">
             <Activity className="w-5 h-5 text-slate-500" />
-            <h2 className="text-lg font-semibold text-slate-800">Advanced Model Analytics: {selectedCrop}</h2>
+            <h2 className="text-lg font-semibold text-slate-800">{copy.advancedModelAnalytics}: {getCropLabel(selectedCrop, locale)}</h2>
           </div>
-          <Suspense fallback={<LoadingPanel title="Advanced Model Analytics" minHeightClassName="min-h-[320px]" />}>
+          <Suspense fallback={<LoadingPanel title={copy.advancedModelAnalytics} loadingMessage={copy.advancedModelAnalyticsLoading} minHeightClassName="min-h-[320px]" />}>
             <ModelAnalytics
               crop={selectedCrop}
               metrics={deferredModelMetrics}
@@ -375,14 +477,14 @@ function App() {
 
         {/* Forecast Section (New) */}
         <div className="mb-8">
-          <Suspense fallback={<LoadingPanel title="Yield Forecast" minHeightClassName="min-h-[280px]" />}>
+          <Suspense fallback={<LoadingPanel title={copy.yieldForecast} loadingMessage={copy.yieldForecastLoading} minHeightClassName="min-h-[280px]" />}>
             <ForecastPanel forecast={deferredForecast} crop={selectedCrop} />
           </Suspense>
         </div>
 
         {/* Consulting Report Section */}
         <div className="mb-8">
-          <Suspense fallback={<LoadingPanel title="Consulting Report" minHeightClassName="min-h-[320px]" />}>
+          <Suspense fallback={<LoadingPanel title={copy.consultingReport} loadingMessage={copy.consultingReportLoading} minHeightClassName="min-h-[320px]" />}>
             <ConsultingReport
               analysis={aiAnalysis}
               metrics={deferredModelMetrics}
@@ -395,7 +497,7 @@ function App() {
         {/* Bottom Section: Charts & Controls */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2">
-            <Suspense fallback={<LoadingPanel title="Real-time Environmental Analysis" minHeightClassName="min-h-[540px]" />}>
+            <Suspense fallback={<LoadingPanel title={copy.realTimeEnvironmentalAnalysis} loadingMessage={copy.realTimeEnvironmentalAnalysisLoading} minHeightClassName="min-h-[540px]" />}>
               <Charts data={deferredHistory} />
             </Suspense>
           </div>
@@ -411,30 +513,30 @@ function App() {
               <div className="flex justify-between items-center mb-2">
                 <h4 className="text-sm font-semibold text-slate-800 flex items-center gap-2">
                   <Leaf className="w-4 h-4 text-green-600" />
-                  Crop Status: {selectedCrop}
+                  {copy.cropStatus}: {getCropLabel(selectedCrop, locale)}
                 </h4>
                 <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium">
-                  {modelMetrics.growth.developmentStage}
+                  {getDevelopmentStageLabel(modelMetrics.growth.developmentStage, locale)}
                 </span>
               </div>
               <div className="w-full bg-slate-100 rounded-full h-2.5 mb-1">
                 <div className="bg-green-600 h-2.5 rounded-full" style={{ width: '75%' }}></div>
               </div>
               <p className="text-xs text-slate-500 flex justify-between">
-                <span>Growth Cycle</span>
+                <span>{copy.growthCycle}</span>
                 <span>
-                  {growthDay ? `Day ${growthDay}` : '-'}
-                  {startDateLabel ? ` (since ${startDateLabel})` : ''}
+                  {growthDay ? (locale === 'ko' ? `${growthDay}일차` : `Day ${growthDay}`) : '-'}
+                  {startDateLabel ? ` (${copy.since} ${startDateLabel})` : ''}
                 </span>
               </p>
-              <p className="text-[11px] text-slate-400 mt-1">Sim Time: {currentDateLabel}</p>
+              <p className="text-[11px] text-slate-400 mt-1">{copy.simTime}: {currentDateLabel}</p>
             </div>
           </div>
         </div>
       </main>
 
       {shouldRenderChat ? (
-        <Suspense fallback={<ChatAssistantFallback onClose={() => setIsChatOpen(false)} />}>
+        <Suspense fallback={<ChatAssistantFallback onClose={() => setIsChatOpen(false)} locale={locale} />}>
           <ChatAssistant
             isOpen={isChatOpen}
             onClose={() => setIsChatOpen(false)}

--- a/frontend/src/components/AiAdvisor.tsx
+++ b/frontend/src/components/AiAdvisor.tsx
@@ -1,6 +1,7 @@
 import { Sparkles, RefreshCw } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useLocale } from '../i18n/LocaleProvider';
 
 interface AiAdvisorProps {
     analysis: string;
@@ -21,13 +22,25 @@ function extractExecutiveSummary(markdown: string): string {
 }
 
 const AiAdvisor = ({ analysis, isLoading, onRefresh }: AiAdvisorProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: 'AI 어드바이저',
+            loading: '데이터를 분석하는 중...',
+            empty: '시스템을 초기화하고 있습니다. 충분한 데이터가 쌓이면 인사이트를 생성합니다...',
+        }
+        : {
+            title: 'AI Advisor',
+            loading: 'Analyzing data...',
+            empty: 'System initializing. Waiting for sufficient data to generate insights...',
+        };
     const summary = analysis ? extractExecutiveSummary(analysis) : "";
     return (
         <div className="bg-gradient-to-br from-indigo-600 to-purple-700 rounded-xl p-6 text-white h-full flex flex-col">
             <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
                     <Sparkles className="w-5 h-5 text-yellow-300" />
-                    <h3 className="font-semibold">AI Advisor</h3>
+                    <h3 className="font-semibold">{copy.title}</h3>
                 </div>
                 <button
                     onClick={onRefresh}
@@ -40,7 +53,7 @@ const AiAdvisor = ({ analysis, isLoading, onRefresh }: AiAdvisorProps) => {
             <div className="flex-1 bg-white/10 rounded-lg p-4 backdrop-blur-sm">
                 {isLoading ? (
                     <div className="flex items-center justify-center h-full">
-                        <span className="text-sm text-indigo-200">Analyzing data...</span>
+                        <span className="text-sm text-indigo-200">{copy.loading}</span>
                     </div>
                 ) : (
                     <div className="text-sm leading-relaxed text-indigo-50 overflow-y-auto max-h-[240px]">
@@ -57,7 +70,7 @@ const AiAdvisor = ({ analysis, isLoading, onRefresh }: AiAdvisorProps) => {
                                 code: ({ ...props }) => <code className="px-1 py-0.5 rounded bg-white/10 text-white" {...props} />,
                             }}
                         >
-                            {summary || "System initializing. Waiting for sufficient data to generate insights..."}
+                            {summary || copy.empty}
                         </ReactMarkdown>
                     </div>
                 )}

--- a/frontend/src/components/Charts.tsx
+++ b/frontend/src/components/Charts.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
 import { Thermometer, Droplets, Wind, Zap, Sun } from 'lucide-react';
 import type { SensorData } from '../types';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleTime } from '../i18n/locale';
 import TimeSeriesChart from './TimeSeriesChart';
 
 interface ChartsProps {
@@ -8,68 +10,106 @@ interface ChartsProps {
 }
 
 const Charts = ({ data }: ChartsProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: '실시간 환경 분석',
+            lastUpdate: '마지막 갱신',
+            airCanopyTemperature: '기온과 캐노피 온도',
+            airTemperature: '기온 (°C)',
+            canopyTemperature: '캐노피 온도 (°C)',
+            vpdTranspiration: '증기압 포차와 증산',
+            vpd: '증기압 포차 (kPa)',
+            transpiration: '증산 속도 (mm H₂O h⁻¹)',
+            photosynthesisResponse: '광합성과 기공 반응',
+            stomatalConductance: '기공전도도 (mol H₂O m⁻² s⁻¹)',
+            grossPhotosynthesis: '총광합성 (µmol m⁻² s⁻¹)',
+            energyBalance: '에너지 수지',
+            sensibleHeat: '현열 플럭스 H (W m⁻²)',
+            latentHeat: '잠열 플럭스 LE (W m⁻²)',
+            electricalDemand: '전력 수요',
+            electricalDemandLine: '전력 수요 (kW)',
+        }
+        : {
+            title: 'Real-time Environmental Analysis',
+            lastUpdate: 'Last update',
+            airCanopyTemperature: 'Air and canopy temperature',
+            airTemperature: 'Air temperature (°C)',
+            canopyTemperature: 'Canopy temperature (°C)',
+            vpdTranspiration: 'Vapor pressure deficit and transpiration',
+            vpd: 'Vapor pressure deficit (kPa)',
+            transpiration: 'Transpiration rate (mm H₂O h⁻¹)',
+            photosynthesisResponse: 'Photosynthesis and stomatal response',
+            stomatalConductance: 'Stomatal conductance (mol H₂O m⁻² s⁻¹)',
+            grossPhotosynthesis: 'Gross photosynthesis (µmol m⁻² s⁻¹)',
+            energyBalance: 'Energy balance',
+            sensibleHeat: 'Sensible heat flux H (W m⁻²)',
+            latentHeat: 'Latent heat flux LE (W m⁻²)',
+            electricalDemand: 'Electrical demand',
+            electricalDemandLine: 'Electrical demand (kW)',
+        };
     const lastTs = data?.length ? data[data.length - 1].timestamp : null;
-    const lastUpdate = lastTs ? new Date(lastTs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '—';
+    const lastUpdate = lastTs ? formatLocaleTime(locale, lastTs, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '—';
 
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between gap-2 mb-2">
                 <div className="flex items-center gap-2">
-                    <h3 className="text-lg font-semibold text-slate-800">Real-time Environmental Analysis</h3>
+                    <h3 className="text-lg font-semibold text-slate-800">{copy.title}</h3>
                 </div>
-                <div className="text-xs text-slate-400">Last update: {lastUpdate}</div>
+                <div className="text-xs text-slate-400">{copy.lastUpdate}: {lastUpdate}</div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <TimeSeriesChart
-                    title="Air and canopy temperature"
+                    title={copy.airCanopyTemperature}
                     data={data}
                     dataKeys={[
-                        { key: "temperature", name: "Air temperature (°C)", color: "#ef4444" },
-                        { key: "canopyTemp", name: "Canopy temperature (°C)", color: "#f59e0b" }
+                        { key: "temperature", name: copy.airTemperature, color: "#ef4444" },
+                        { key: "canopyTemp", name: copy.canopyTemperature, color: "#f59e0b" }
                     ]}
                     icon={<Thermometer className="w-4 h-4 text-red-500" />}
                     height={200}
                 />
 
                 <TimeSeriesChart
-                    title="Vapor pressure deficit and transpiration"
+                    title={copy.vpdTranspiration}
                     data={data}
                     dataKeys={[
-                        { key: "vpd", name: "Vapor pressure deficit (kPa)", color: "#8b5cf6" },
-                        { key: "transpiration", name: "Transpiration rate (mm H₂O h⁻¹)", color: "#06b6d4" }
+                        { key: "vpd", name: copy.vpd, color: "#8b5cf6" },
+                        { key: "transpiration", name: copy.transpiration, color: "#06b6d4" }
                     ]}
                     icon={<Droplets className="w-4 h-4 text-blue-500" />}
                     height={200}
                 />
 
                 <TimeSeriesChart
-                    title="Photosynthesis and stomatal response"
+                    title={copy.photosynthesisResponse}
                     data={data}
                     dataKeys={[
-                        { key: "stomatalConductance", name: "Stomatal conductance (mol H₂O m⁻² s⁻¹)", color: "#10b981" },
-                        { key: "photosynthesis", name: "Gross photosynthesis (µmol m⁻² s⁻¹)", color: "#22c55e" }
+                        { key: "stomatalConductance", name: copy.stomatalConductance, color: "#10b981" },
+                        { key: "photosynthesis", name: copy.grossPhotosynthesis, color: "#22c55e" }
                     ]}
                     icon={<Wind className="w-4 h-4 text-green-500" />}
                     height={200}
                 />
 
                 <TimeSeriesChart
-                    title="Energy balance"
+                    title={copy.energyBalance}
                     data={data}
                     dataKeys={[
-                        { key: "hFlux", name: "Sensible heat flux H (W m⁻²)", color: "#fb7185" },
-                        { key: "leFlux", name: "Latent heat flux LE (W m⁻²)", color: "#0ea5e9" }
+                        { key: "hFlux", name: copy.sensibleHeat, color: "#fb7185" },
+                        { key: "leFlux", name: copy.latentHeat, color: "#0ea5e9" }
                     ]}
                     icon={<Sun className="w-4 h-4 text-amber-500" />}
                     height={200}
                 />
 
                 <TimeSeriesChart
-                    title="Electrical demand"
+                    title={copy.electricalDemand}
                     data={data}
                     dataKeys={[
-                        { key: "energyUsage", name: "Electrical demand (kW)", color: "#f59e0b" }
+                        { key: "energyUsage", name: copy.electricalDemandLine, color: "#f59e0b" }
                     ]}
                     icon={<Zap className="w-4 h-4 text-orange-500" />}
                     height={200}

--- a/frontend/src/components/ChatAssistant.tsx
+++ b/frontend/src/components/ChatAssistant.tsx
@@ -9,6 +9,7 @@ import type {
     WeatherOutlook,
 } from '../types';
 import { API_URL } from '../config';
+import { useLocale } from '../i18n/LocaleProvider';
 import { buildAiDashboardContext } from '../utils/aiDashboardContext';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -42,8 +43,26 @@ const ChatAssistant = ({
     weather = null,
     rtrProfile = null,
 }: ChatAssistantProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            initialMessage: '안녕하세요! 온실 어시스턴트입니다. 현재 생육 상태나 제어 전략에 대해 물어보세요.',
+            title: '어시스턴트',
+            placeholder: '메시지를 입력하세요...',
+            noResponse: '응답이 없습니다.',
+            unknownError: '알 수 없는 오류가 발생했습니다.',
+            aiUnavailable: 'AI 채팅을 사용할 수 없습니다',
+        }
+        : {
+            initialMessage: "Hello! I'm your greenhouse assistant. Ask me anything about your crop status.",
+            title: 'Assistant',
+            placeholder: 'Type a message...',
+            noResponse: 'No response.',
+            unknownError: 'An unknown error occurred.',
+            aiUnavailable: 'AI chat is unavailable',
+        };
     const [messages, setMessages] = useState<{ role: 'user' | 'ai', text: string }[]>([
-        { role: 'ai', text: "Hello! I'm your greenhouse assistant. Ask me anything about your crop status." }
+        { role: 'ai', text: copy.initialMessage }
     ]);
     const [input, setInput] = useState("");
     const [isSending, setIsSending] = useState(false);
@@ -80,7 +99,7 @@ const ChatAssistant = ({
                         weather,
                         rtrProfile,
                     }),
-                    language: 'en'
+                    language: locale
                 })
             });
             const raw = await res.text();
@@ -96,11 +115,11 @@ const ChatAssistant = ({
                 throw new Error(message);
             }
 
-            setMessages(prev => [...prev, { role: 'ai', text: json?.text || "No response." }]);
+            setMessages(prev => [...prev, { role: 'ai', text: json?.text || copy.noResponse }]);
         } catch (e) {
             const message =
-                e instanceof Error ? e.message : "An unknown error occurred.";
-            setMessages(prev => [...prev, { role: 'ai', text: `AI chat is unavailable: ${message}` }]);
+                e instanceof Error ? e.message : copy.unknownError;
+            setMessages(prev => [...prev, { role: 'ai', text: `${copy.aiUnavailable}: ${message}` }]);
         } finally {
             setIsSending(false);
         }
@@ -113,7 +132,7 @@ const ChatAssistant = ({
             <div className="bg-slate-900 p-4 flex justify-between items-center text-white">
                 <div className="flex items-center gap-2">
                     <Bot className="w-5 h-5 text-green-400" />
-                    <span className="font-medium">Assistant</span>
+                    <span className="font-medium">{copy.title}</span>
                 </div>
                 <button onClick={onClose} className="hover:text-slate-300"><X className="w-5 h-5" /></button>
             </div>
@@ -151,7 +170,7 @@ const ChatAssistant = ({
                     value={input}
                     onChange={e => setInput(e.target.value)}
                     onKeyDown={e => e.key === 'Enter' && !isSending && handleSend()}
-                    placeholder="Type a message..."
+                    placeholder={copy.placeholder}
                     className="flex-1 px-4 py-2 bg-slate-100 rounded-full focus:outline-none focus:ring-2 focus:ring-green-500 text-sm"
                 />
                 <button

--- a/frontend/src/components/ConsultingReport.tsx
+++ b/frontend/src/components/ConsultingReport.tsx
@@ -1,5 +1,7 @@
 import { FileText } from 'lucide-react';
 import type { AdvancedModelMetrics, SensorData, CropType } from '../types';
+import { useLocale } from '../i18n/LocaleProvider';
+import { getCropLabel } from '../utils/displayCopy';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -11,24 +13,49 @@ interface ConsultingReportProps {
 }
 
 const ConsultingReport = ({ analysis, metrics, crop }: ConsultingReportProps) => {
+    const { locale } = useLocale();
+    const cropLabel = getCropLabel(crop, locale);
+    const copy = locale === 'ko'
+        ? {
+            title: '컨설팅 리포트',
+            executiveSummary: '핵심 요약',
+            aiNotes: 'AI 컨설팅 메모',
+            waiting: 'AI 컨설팅 결과를 기다리는 중...',
+            favorable: '양호한 편',
+            stable: '안정적',
+            yieldOutlook: '수확 전망',
+            energyUsage: '에너지 사용량',
+            confidence: '신뢰도',
+        }
+        : {
+            title: 'Consulting Report',
+            executiveSummary: 'Executive Summary',
+            aiNotes: 'AI Consulting Notes',
+            waiting: 'Waiting for AI consulting output...',
+            favorable: 'favorable',
+            stable: 'stable',
+            yieldOutlook: 'Yield Outlook',
+            energyUsage: 'Energy Usage',
+            confidence: 'confidence',
+        };
     return (
         <div className="bg-white p-6 rounded-xl border border-slate-100 shadow-sm">
             <div className="flex items-center gap-2 mb-4 text-slate-800">
                 <FileText className="w-5 h-5 text-indigo-600" />
-                <h3 className="text-lg font-semibold">Consulting Report</h3>
+                <h3 className="text-lg font-semibold">{copy.title}</h3>
             </div>
             <div className="space-y-4">
                 <div className="p-4 bg-slate-50 rounded-lg border border-slate-100">
-                    <h4 className="text-sm font-medium text-slate-700 mb-2">Executive Summary</h4>
+                    <h4 className="text-sm font-medium text-slate-700 mb-2">{copy.executiveSummary}</h4>
                     <p className="text-sm text-slate-600 leading-relaxed">
-                        Current conditions for {crop} are {metrics.growth.growthRate > 0 ? "favorable" : "stable"}.
-                        Biomass accumulation is {metrics.growth.biomass.toFixed(1)} g/m².
-                        Energy efficiency is operating at a COP of {metrics.energy.efficiency.toFixed(1)}.
+                        {locale === 'ko'
+                            ? `현재 ${cropLabel} 상태는 ${metrics.growth.growthRate > 0 ? copy.favorable : copy.stable}입니다. 바이오매스 누적량은 ${metrics.growth.biomass.toFixed(1)} g/m²이고, 에너지 효율은 COP ${metrics.energy.efficiency.toFixed(1)} 수준입니다.`
+                            : `Current conditions for ${cropLabel} are ${metrics.growth.growthRate > 0 ? copy.favorable : copy.stable}. Biomass accumulation is ${metrics.growth.biomass.toFixed(1)} g/m². Energy efficiency is operating at a COP of ${metrics.energy.efficiency.toFixed(1)}.`}
                     </p>
                 </div>
 
                 <div className="p-4 bg-white rounded-lg border border-slate-200">
-                    <h4 className="text-sm font-medium text-slate-700 mb-2">AI Consulting Notes</h4>
+                    <h4 className="text-sm font-medium text-slate-700 mb-2">{copy.aiNotes}</h4>
                     <div className="text-sm text-slate-700 leading-relaxed">
                         <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
@@ -43,21 +70,25 @@ const ConsultingReport = ({ analysis, metrics, crop }: ConsultingReportProps) =>
                                 code: ({ ...props }) => <code className="px-1 py-0.5 rounded bg-slate-100 text-slate-900" {...props} />,
                             }}
                         >
-                            {analysis || "Waiting for AI consulting output..."}
+                            {analysis || copy.waiting}
                         </ReactMarkdown>
                     </div>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div className="p-4 bg-green-50 rounded-lg border border-green-100">
-                        <h4 className="text-sm font-medium text-green-800 mb-1">Yield Outlook</h4>
+                        <h4 className="text-sm font-medium text-green-800 mb-1">{copy.yieldOutlook}</h4>
                         <p className="text-xs text-green-700">
-                            Projected yield of {metrics.yield.predictedWeekly.toFixed(1)} kg/m² with {metrics.yield.confidence}% confidence.
+                            {locale === 'ko'
+                                ? `${metrics.yield.predictedWeekly.toFixed(1)} kg/m² 수준이 예상되며 ${copy.confidence}는 ${metrics.yield.confidence}%입니다.`
+                                : `Projected yield of ${metrics.yield.predictedWeekly.toFixed(1)} kg/m² with ${metrics.yield.confidence}% confidence.`}
                         </p>
                     </div>
                     <div className="p-4 bg-orange-50 rounded-lg border border-orange-100">
-                        <h4 className="text-sm font-medium text-orange-800 mb-1">Energy Usage</h4>
+                        <h4 className="text-sm font-medium text-orange-800 mb-1">{copy.energyUsage}</h4>
                         <p className="text-xs text-orange-700">
-                            Current power: {metrics.energy.consumption.toFixed(2)} kW. Est. cost (per hour): {metrics.energy.costPrediction.toFixed(2)}.
+                            {locale === 'ko'
+                                ? `현재 전력은 ${metrics.energy.consumption.toFixed(2)} kW이며, 시간당 예상 비용은 ${metrics.energy.costPrediction.toFixed(2)}입니다.`
+                                : `Current power: ${metrics.energy.consumption.toFixed(2)} kW. Est. cost (per hour): ${metrics.energy.costPrediction.toFixed(2)}.`}
                         </p>
                     </div>
                 </div>

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import type { ControlStatus, TemperatureSettings } from '../types';
 import { Fan, Droplets, Thermometer, Sun } from 'lucide-react';
+import { useLocale } from '../i18n/LocaleProvider';
 
 interface ControlPanelProps {
     status: ControlStatus;
@@ -8,9 +9,31 @@ interface ControlPanelProps {
 }
 
 const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: '수동 제어',
+            ventilation: '환기',
+            irrigation: '관수',
+            heating: '난방',
+            shading: '차광',
+            temperatureSettings: '온도 설정',
+            heatingThreshold: '난방 시작 온도',
+            coolingThreshold: '냉방 시작 온도',
+        }
+        : {
+            title: 'Manual Controls',
+            ventilation: 'Ventilation',
+            irrigation: 'Irrigation',
+            heating: 'Heating',
+            shading: 'Shading',
+            temperatureSettings: 'Temperature Settings',
+            heatingThreshold: 'Heating Threshold',
+            coolingThreshold: 'Cooling Threshold',
+        };
     return (
         <div className="bg-white p-6 rounded-xl border border-slate-100 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-800 mb-4">Manual Controls</h3>
+            <h3 className="text-lg font-semibold text-slate-800 mb-4">{copy.title}</h3>
             <div className="grid grid-cols-2 gap-4">
                 <button
                     onClick={() => onToggle('ventilation')}
@@ -18,7 +41,7 @@ const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps)
                         }`}
                 >
                     <Fan className="w-6 h-6" />
-                    <span className="text-sm font-medium">Ventilation</span>
+                    <span className="text-sm font-medium">{copy.ventilation}</span>
                 </button>
                 <button
                     onClick={() => onToggle('irrigation')}
@@ -26,7 +49,7 @@ const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps)
                         }`}
                 >
                     <Droplets className="w-6 h-6" />
-                    <span className="text-sm font-medium">Irrigation</span>
+                    <span className="text-sm font-medium">{copy.irrigation}</span>
                 </button>
                 <button
                     onClick={() => onToggle('heating')}
@@ -34,7 +57,7 @@ const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps)
                         }`}
                 >
                     <Thermometer className="w-6 h-6" />
-                    <span className="text-sm font-medium">Heating</span>
+                    <span className="text-sm font-medium">{copy.heating}</span>
                 </button>
                 <button
                     onClick={() => onToggle('shading')}
@@ -42,15 +65,15 @@ const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps)
                         }`}
                 >
                     <Sun className="w-6 h-6" />
-                    <span className="text-sm font-medium">Shading</span>
+                    <span className="text-sm font-medium">{copy.shading}</span>
                 </button>
             </div>
 
             <div className="mt-6 pt-6 border-t border-slate-100">
-                <h4 className="text-sm font-medium text-slate-700 mb-3">Temperature Settings</h4>
+                <h4 className="text-sm font-medium text-slate-700 mb-3">{copy.temperatureSettings}</h4>
                 <div className="space-y-4">
                     <div>
-                        <label className="text-xs text-slate-500 block mb-1">Heating Threshold</label>
+                        <label className="text-xs text-slate-500 block mb-1">{copy.heatingThreshold}</label>
                         <input
                             type="range"
                             min="10" max="30"
@@ -65,7 +88,7 @@ const ControlPanel = ({ status, onToggle, onSettingsChange }: ControlPanelProps)
                         </div>
                     </div>
                     <div>
-                        <label className="text-xs text-slate-500 block mb-1">Cooling Threshold</label>
+                        <label className="text-xs text-slate-500 block mb-1">{copy.coolingThreshold}</label>
                         <input
                             type="range"
                             min="15" max="35"

--- a/frontend/src/components/CropDetails.tsx
+++ b/frontend/src/components/CropDetails.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { Settings, Sprout, Activity, Droplets, Leaf, CheckCircle } from 'lucide-react';
 import type { SensorData, AdvancedModelMetrics, CropType } from '../types';
 import { API_URL } from '../config';
-import { UNIT_LABELS, getCropStatusLabel } from '../utils/displayCopy';
+import { useLocale } from '../i18n/LocaleProvider';
+import { UNIT_LABELS, getCropLabel, getCropStatusLabel } from '../utils/displayCopy';
 import { formatMetricValue } from '../utils/formatValue';
 
 interface CropDetailsProps {
@@ -12,6 +13,60 @@ interface CropDetailsProps {
 }
 
 const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            managementTitle: `${getCropLabel(crop, locale)} 관리 및 작업`,
+            hideSettings: '설정 숨기기',
+            showSettings: '설정 보기',
+            fruitsPerTruss: '화방당 과실 수',
+            update: '업데이트',
+            fruitsPerTrussHint: '권장값: 광량에 따라 3-6과 수준으로 관리하세요.',
+            pruningThreshold: '전정 기준 마디 수',
+            targetLeafCount: '목표 엽수',
+            applySettings: '설정 적용',
+            processing: '처리 중...',
+            markPruned: '전정 완료 표시',
+            trussStatus: '화방 상태',
+            growthStatus: '생육 상태',
+            leafAreaIndex: '엽면적지수',
+            dailyBiomassGrowth: '일일 바이오매스 증가',
+            biomassTrend: '바이오매스 누적 추세',
+            yieldPotential: '수확 잠재력',
+            confidence: '신뢰도',
+            transpiration: '증산',
+            canopyActivity: '캐노피 활동',
+            updateSuccess: '설정을 업데이트했습니다.',
+            updateFailure: '설정 업데이트에 실패했습니다.',
+            pruneSuccess: '전정 기준을 초기화했습니다.',
+            pruneFailure: '전정 처리에 실패했습니다.',
+        }
+        : {
+            managementTitle: `${crop} Management & Operations`,
+            hideSettings: 'Hide Settings',
+            showSettings: 'Show Settings',
+            fruitsPerTruss: 'Fruits per Truss',
+            update: 'Update',
+            fruitsPerTrussHint: 'Recommended: 3-6 fruits depending on light levels.',
+            pruningThreshold: 'Pruning Threshold (Nodes)',
+            targetLeafCount: 'Target Leaf Count',
+            applySettings: 'Apply Settings',
+            processing: 'Processing...',
+            markPruned: 'Mark Pruned',
+            trussStatus: 'Truss status',
+            growthStatus: 'Growth status',
+            leafAreaIndex: 'Leaf area index',
+            dailyBiomassGrowth: 'Daily biomass growth',
+            biomassTrend: 'Biomass accumulation trend',
+            yieldPotential: 'Yield Potential',
+            confidence: 'Confidence',
+            transpiration: 'Transpiration',
+            canopyActivity: 'Canopy Activity',
+            updateSuccess: 'Configuration updated successfully!',
+            updateFailure: 'Failed to update configuration.',
+            pruneSuccess: 'Pruning baseline reset successfully.',
+            pruneFailure: 'Failed to mark pruning.',
+        };
     const [showSettings, setShowSettings] = useState(false);
 
     // Tomato Config
@@ -63,10 +118,10 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                 throw new Error(data?.detail ?? data?.message ?? 'Failed to update');
             }
 
-            alert(data?.message ?? 'Configuration updated successfully!');
+            alert(locale === 'ko' ? copy.updateSuccess : data?.message ?? copy.updateSuccess);
         } catch (err) {
             console.error("Error updating config:", err);
-            alert(err instanceof Error ? err.message : 'Failed to update configuration.');
+            alert(err instanceof Error ? err.message : copy.updateFailure);
         }
     };
 
@@ -80,10 +135,10 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                 throw new Error(data?.detail ?? data?.message ?? 'Failed to prune');
             }
 
-            alert(data?.message ?? 'Pruning baseline reset successfully.');
+            alert(locale === 'ko' ? copy.pruneSuccess : data?.message ?? copy.pruneSuccess);
         } catch (err) {
             console.error("Error pruning:", err);
-            alert(err instanceof Error ? err.message : 'Failed to mark pruning.');
+            alert(err instanceof Error ? err.message : copy.pruneFailure);
         } finally {
             setPruneLoading(false);
         }
@@ -96,13 +151,13 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                 <div className="p-4 bg-slate-50 border-b border-slate-100 flex justify-between items-center">
                     <div className="flex items-center gap-2 text-slate-800 font-semibold">
                         <Settings className="w-5 h-5 text-slate-500" />
-                        <span>{crop} Management & Operations</span>
+                        <span>{copy.managementTitle}</span>
                     </div>
                     <button
                         onClick={() => setShowSettings(!showSettings)}
                         className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                     >
-                        {showSettings ? 'Hide Settings' : 'Show Settings'}
+                        {showSettings ? copy.hideSettings : copy.showSettings}
                     </button>
                 </div>
 
@@ -111,7 +166,7 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                         {crop === 'Tomato' ? (
                             <div className="space-y-4">
                                 <div>
-                                    <label className="block text-sm font-medium text-slate-700 mb-1">Fruits per Truss</label>
+                                    <label className="block text-sm font-medium text-slate-700 mb-1">{copy.fruitsPerTruss}</label>
                                     <div className="flex gap-2">
                                         <input
                                             type="number"
@@ -124,17 +179,17 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                                             onClick={handleUpdateConfig}
                                             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium"
                                         >
-                                            Update
+                                            {copy.update}
                                         </button>
                                     </div>
-                                    <p className="text-xs text-slate-500 mt-1">Recommended: 3-6 fruits depending on light levels.</p>
+                                    <p className="text-xs text-slate-500 mt-1">{copy.fruitsPerTrussHint}</p>
                                 </div>
                             </div>
                         ) : (
                             <div className="space-y-4">
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <div>
-                                        <label className="block text-sm font-medium text-slate-700 mb-1">Pruning Threshold (Nodes)</label>
+                                        <label className="block text-sm font-medium text-slate-700 mb-1">{copy.pruningThreshold}</label>
                                         <input
                                             type="number"
                                             min="10" max="30"
@@ -144,7 +199,7 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                                         />
                                     </div>
                                     <div>
-                                        <label className="block text-sm font-medium text-slate-700 mb-1">Target Leaf Count</label>
+                                        <label className="block text-sm font-medium text-slate-700 mb-1">{copy.targetLeafCount}</label>
                                         <input
                                             type="number"
                                             min="10" max="30"
@@ -159,7 +214,7 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                                         onClick={handleUpdateConfig}
                                         className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium"
                                     >
-                                        Apply Settings
+                                        {copy.applySettings}
                                     </button>
                                     <button
                                         onClick={handlePrune}
@@ -167,7 +222,7 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                                         className="flex-1 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 font-medium flex items-center justify-center gap-2 disabled:opacity-50"
                                     >
                                         <CheckCircle className="w-4 h-4" />
-                                        {pruneLoading ? 'Processing...' : 'Mark Pruned'}
+                                        {pruneLoading ? copy.processing : copy.markPruned}
                                     </button>
                                 </div>
                             </div>
@@ -181,15 +236,15 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Sprout className="w-4 h-4" />
-                        <span className="text-sm font-medium">{crop === 'Tomato' ? 'Truss status' : 'Growth status'}</span>
+                        <span className="text-sm font-medium">{crop === 'Tomato' ? copy.trussStatus : copy.growthStatus}</span>
                     </div>
                     <div className="space-y-1">
                         <div className="flex justify-between text-sm">
-                            <span className="text-slate-600">{getCropStatusLabel(crop)}</span>
+                            <span className="text-slate-600">{getCropStatusLabel(crop, locale)}</span>
                             <span className="font-semibold text-slate-800">{growthStatusValue ?? '-'}</span>
                         </div>
                         <div className="flex justify-between text-sm">
-                            <span className="text-slate-600">Leaf area index</span>
+                            <span className="text-slate-600">{copy.leafAreaIndex}</span>
                             <span className="font-semibold text-green-600">{metrics.growth.lai.toFixed(2)}</span>
                         </div>
                     </div>
@@ -199,31 +254,31 @@ const CropDetails = ({ crop, currentData, metrics }: CropDetailsProps) => {
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Activity className="w-4 h-4" />
-                        <span className="text-sm font-medium">Daily biomass growth</span>
+                        <span className="text-sm font-medium">{copy.dailyBiomassGrowth}</span>
                     </div>
                     <div className="text-2xl font-bold text-green-600">{metrics.growth.growthRate.toFixed(1)}</div>
                     <p className="text-xs text-slate-400 mt-1 leading-snug">{UNIT_LABELS.biomassGrowthRate}</p>
-                    <p className="text-xs text-slate-400 mt-1">Biomass accumulation trend</p>
+                    <p className="text-xs text-slate-400 mt-1">{copy.biomassTrend}</p>
                 </div>
 
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Leaf className="w-4 h-4" />
-                        <span className="text-sm font-medium">Yield Potential</span>
+                        <span className="text-sm font-medium">{copy.yieldPotential}</span>
                     </div>
                     <div className="text-2xl font-bold text-emerald-600">{metrics.yield.predictedWeekly.toFixed(1)}</div>
                     <p className="text-xs text-slate-400 mt-1 leading-snug">{UNIT_LABELS.weeklyYield}</p>
-                    <p className="text-xs text-slate-400 mt-1">Confidence: {metrics.yield.confidence}%</p>
+                    <p className="text-xs text-slate-400 mt-1">{copy.confidence}: {metrics.yield.confidence}%</p>
                 </div>
 
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Droplets className="w-4 h-4" />
-                        <span className="text-sm font-medium">Transpiration</span>
+                        <span className="text-sm font-medium">{copy.transpiration}</span>
                     </div>
                     <div className="text-2xl font-bold text-cyan-600">{formatMetricValue(currentData.transpiration)}</div>
                     <p className="text-xs text-slate-400 mt-1 leading-snug">{UNIT_LABELS.transpirationRate}</p>
-                    <p className="text-xs text-slate-400 mt-1">Canopy Activity</p>
+                    <p className="text-xs text-slate-400 mt-1">{copy.canopyActivity}</p>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/ForecastPanel.tsx
+++ b/frontend/src/components/ForecastPanel.tsx
@@ -1,6 +1,7 @@
 import { TrendingUp, Calendar, Leaf, Droplets, Zap } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import type { CropType, ForecastData } from "../types";
+import { useLocale } from "../i18n/LocaleProvider";
 import { UNIT_LABELS, getForecastTitle } from "../utils/displayCopy";
 
 interface ForecastPanelProps {
@@ -9,11 +10,33 @@ interface ForecastPanelProps {
 }
 
 const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            waiting: '예측 데이터를 기다리는 중...',
+            noHarvest: '수확 예측 없음',
+            noHarvestDescription: '현재 생육 단계 기준으로 향후 7일 내 수확이 예상되지 않습니다.',
+            yield: '7일 수확량',
+            transpiration: '증산량',
+            energyUse: '에너지 사용량',
+            harvestYield: '수확량 (kg)',
+            cropTranspiration: '작물 증산량 (mm H₂O)',
+        }
+        : {
+            waiting: 'Waiting for forecast data...',
+            noHarvest: 'No Harvest Predicted',
+            noHarvestDescription: 'No harvest is expected within the next 7 days based on current growth stage.',
+            yield: '7-Day Yield',
+            transpiration: 'Transpiration',
+            energyUse: 'Energy Usage',
+            harvestYield: 'Harvest yield (kg)',
+            cropTranspiration: 'Crop transpiration (mm H₂O)',
+        };
     if (!forecast || !forecast.daily || forecast.daily.length === 0) {
         return (
             <div className="bg-white p-6 rounded-xl border border-slate-100 shadow-sm h-full flex flex-col items-center justify-center text-slate-400">
                 <Calendar className="w-10 h-10 mb-2 opacity-50" />
-                <p>Waiting for forecast data...</p>
+                <p>{copy.waiting}</p>
             </div>
         );
     }
@@ -25,14 +48,14 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
             {/* Alert Box if no harvest */}
             {!hasHarvest && (
                 <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 flex items-start gap-3">
-                    <TrendingUp className="w-5 h-5 text-amber-600 mt-0.5" />
-                    <div>
-                        <p className="font-semibold">No Harvest Predicted</p>
-                        <p className="mt-1 text-amber-700">
-                            No harvest is expected within the next 7 days based on current growth stage.
-                        </p>
+                        <TrendingUp className="w-5 h-5 text-amber-600 mt-0.5" />
+                        <div>
+                            <p className="font-semibold">{copy.noHarvest}</p>
+                            <p className="mt-1 text-amber-700">
+                                {copy.noHarvestDescription}
+                            </p>
+                        </div>
                     </div>
-                </div>
             )}
 
             {/* Summary Cards */}
@@ -40,7 +63,7 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Leaf className="w-4 h-4 text-green-500" />
-                        <span className="text-sm font-medium">7-Day Yield</span>
+                        <span className="text-sm font-medium">{copy.yield}</span>
                     </div>
                     <div className="text-2xl font-bold text-slate-800">{hasHarvest ? `${forecast.total_harvest_kg?.toFixed(1)}` : "0.0"}</div>
                     <p className="mt-1 text-xs leading-snug text-slate-400">{UNIT_LABELS.weeklyYield}</p>
@@ -49,7 +72,7 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Droplets className="w-4 h-4 text-cyan-500" />
-                        <span className="text-sm font-medium">Transpiration</span>
+                        <span className="text-sm font-medium">{copy.transpiration}</span>
                     </div>
                     <div className="text-2xl font-bold text-slate-800">{forecast.total_ETc_mm?.toFixed(1) || 0}</div>
                     <p className="mt-1 text-xs leading-snug text-slate-400">{UNIT_LABELS.transpirationDepth}</p>
@@ -58,7 +81,7 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
                 <div className="bg-white p-4 rounded-xl border border-slate-100 shadow-sm">
                     <div className="flex items-center gap-2 mb-2 text-slate-500">
                         <Zap className="w-4 h-4 text-orange-500" />
-                        <span className="text-sm font-medium">Energy Usage</span>
+                        <span className="text-sm font-medium">{copy.energyUse}</span>
                     </div>
                     <div className="text-2xl font-bold text-slate-800">{forecast.total_energy_kWh?.toFixed(1) || 0}</div>
                     <p className="mt-1 text-xs leading-snug text-slate-400">{UNIT_LABELS.energyUse}</p>
@@ -70,7 +93,7 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
                 <div className="flex items-center justify-between mb-6">
                     <h3 className="text-lg font-semibold text-slate-800 flex items-center gap-2">
                         <Calendar className="w-5 h-5 text-slate-500" />
-                        {getForecastTitle(crop)}
+                        {getForecastTitle(crop, locale)}
                     </h3>
                 </div>
                 <div className="h-64 w-full">
@@ -99,8 +122,8 @@ const ForecastPanel = ({ forecast, crop }: ForecastPanelProps) => {
                                 cursor={{ fill: '#f8fafc' }}
                                 formatter={(value: number, name: string) => [value.toFixed(1), name]}
                             />
-                            <Bar dataKey="harvest_kg" name="Harvest yield (kg)" fill="#22c55e" radius={[4, 4, 0, 0]} maxBarSize={40} />
-                            <Bar dataKey="ETc_mm" name="Crop transpiration (mm H₂O)" fill="#06b6d4" radius={[4, 4, 0, 0]} maxBarSize={40} />
+                            <Bar dataKey="harvest_kg" name={copy.harvestYield} fill="#22c55e" radius={[4, 4, 0, 0]} maxBarSize={40} />
+                            <Bar dataKey="ETc_mm" name={copy.cropTranspiration} fill="#06b6d4" radius={[4, 4, 0, 0]} maxBarSize={40} />
                         </BarChart>
                     </ResponsiveContainer>
                 </div>

--- a/frontend/src/components/ModelAnalytics.tsx
+++ b/frontend/src/components/ModelAnalytics.tsx
@@ -2,7 +2,9 @@ import { memo } from 'react';
 import type { AdvancedModelMetrics, CropType, ForecastData, MetricHistoryPoint } from '../types';
 import { TrendingUp, Zap, Scale, Leaf } from 'lucide-react';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
-import { UNIT_LABELS, getCropModelLabel } from '../utils/displayCopy';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleDate, formatLocaleTime } from '../i18n/locale';
+import { UNIT_LABELS, getCropModelLabel, getDevelopmentStageLabel } from '../utils/displayCopy';
 
 interface ModelAnalyticsProps {
     crop: CropType;
@@ -11,13 +13,53 @@ interface ModelAnalyticsProps {
     forecast: ForecastData | null;
 }
 
-const formatTimeLabel = (timestamp: number) =>
-    new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-
-const formatDayLabel = (date: string) =>
-    new Date(date).toLocaleDateString([], { month: 'numeric', day: 'numeric' });
-
 const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyticsProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            growthModel: '생육 모델',
+            yieldForecast: '수확 예측',
+            aiInference: 'AI 추론',
+            energyModel: '에너지 모델',
+            efficiencyCost: '효율 및 비용',
+            biomassLine: '바이오매스 (g m⁻²)',
+            stage: '단계',
+            rate: '증가율',
+            harvestForecast: '수확 예측 (kg)',
+            confidence: '신뢰도',
+            harvestReady: '수확 가능 과실',
+            electricalDemand: '전력 수요 (kW)',
+            thermalLoad: '열부하 (kW)',
+            load: '부하',
+            estimatedCost: '예상 비용',
+            optimizationInsight: '최적화 인사이트',
+            highEfficiency: '효율이 높게 유지되고 있습니다. 현재 HVAC 반응은 예상 제어 범위 안에 있습니다.',
+            efficiencyDrop: '효율 저하가 감지됩니다. 환기 손실과 냉난방 단계 제어를 점검하세요.',
+        }
+        : {
+            growthModel: 'Growth Model',
+            yieldForecast: 'Yield Forecast',
+            aiInference: 'AI Inference',
+            energyModel: 'Energy Model',
+            efficiencyCost: 'Efficiency & Cost',
+            biomassLine: 'Biomass (g m⁻²)',
+            stage: 'Stage',
+            rate: 'Rate',
+            harvestForecast: 'Harvest forecast (kg)',
+            confidence: 'Confidence',
+            harvestReady: 'Harvest-ready fruits',
+            electricalDemand: 'Electrical demand (kW)',
+            thermalLoad: 'Thermal load (kW)',
+            load: 'Load',
+            estimatedCost: 'Est. Cost',
+            optimizationInsight: 'Optimization Insight',
+            highEfficiency: 'High efficiency maintained. Current HVAC response is within the expected control envelope.',
+            efficiencyDrop: 'Efficiency drop detected. Check ventilation losses and cooling or heating staging.',
+        };
+    const formatTimeLabel = (timestamp: number) =>
+        formatLocaleTime(locale, timestamp, { hour: '2-digit', minute: '2-digit' });
+    const formatDayLabel = (date: string) =>
+        formatLocaleDate(locale, `${date}T00:00:00`, { month: 'numeric', day: 'numeric' });
     const biomass = metrics.growth.biomass;
     const lai = metrics.growth.lai;
     const predictedWeekly = metrics.yield.predictedWeekly;
@@ -68,8 +110,8 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                             <Leaf className="w-5 h-5" />
                         </div>
                         <div>
-                            <h3 className="font-semibold text-slate-800">Growth Model</h3>
-                            <p className="text-xs text-slate-400">{getCropModelLabel(crop)}</p>
+                            <h3 className="font-semibold text-slate-800">{copy.growthModel}</h3>
+                            <p className="text-xs text-slate-400">{getCropModelLabel(crop, locale)}</p>
                         </div>
                     </div>
                     <div className="text-right">
@@ -89,13 +131,13 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                                 itemStyle={{ fontSize: '12px' }}
                                 formatter={(value: number, name: string) => [value.toFixed(1), name]}
                             />
-                            <Line type="monotone" dataKey="biomass" stroke="#16a34a" strokeWidth={2} dot={false} name="Biomass (g m⁻²)" />
+                            <Line type="monotone" dataKey="biomass" stroke="#16a34a" strokeWidth={2} dot={false} name={copy.biomassLine} />
                         </LineChart>
                     </ResponsiveContainer>
                 </div>
                 <div className="mt-2 flex justify-between text-xs text-slate-500">
-                    <span>Stage: <span className="font-medium text-green-700">{metrics.growth.developmentStage}</span></span>
-                    <span>Rate: +{metrics.growth.growthRate.toFixed(1)} g m⁻² d⁻¹</span>
+                    <span>{copy.stage}: <span className="font-medium text-green-700">{getDevelopmentStageLabel(metrics.growth.developmentStage, locale)}</span></span>
+                    <span>{copy.rate}: +{metrics.growth.growthRate.toFixed(1)} g m⁻² d⁻¹</span>
                 </div>
             </div>
 
@@ -107,8 +149,8 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                             <Scale className="w-5 h-5" />
                         </div>
                         <div>
-                            <h3 className="font-semibold text-slate-800">Yield Forecast</h3>
-                            <p className="text-xs text-slate-400">AI Inference</p>
+                            <h3 className="font-semibold text-slate-800">{copy.yieldForecast}</h3>
+                            <p className="text-xs text-slate-400">{copy.aiInference}</p>
                         </div>
                     </div>
                     <div className="text-right">
@@ -129,7 +171,7 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                                 itemStyle={{ fontSize: '12px' }}
                                 formatter={(value: number, name: string) => [value.toFixed(1), name]}
                             />
-                            <Bar dataKey="harvestKg" name="Harvest forecast (kg)" radius={[4, 4, 0, 0]}>
+                            <Bar dataKey="harvestKg" name={copy.harvestForecast} radius={[4, 4, 0, 0]}>
                                 {yieldData.map((_entry, index) => (
                                     <Cell key={`cell-${index}`} fill={index === 0 ? '#f97316' : '#fdba74'} />
                                 ))}
@@ -138,8 +180,8 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                     </ResponsiveContainer>
                 </div>
                 <div className="mt-2 flex justify-between text-xs text-slate-500">
-                    <span>Confidence: <span className="font-medium text-orange-700">{metrics.yield.confidence}%</span></span>
-                    <span>Harvest-ready fruits: ~{metrics.yield.harvestableFruits.toFixed(0)}</span>
+                    <span>{copy.confidence}: <span className="font-medium text-orange-700">{metrics.yield.confidence}%</span></span>
+                    <span>{copy.harvestReady}: ~{metrics.yield.harvestableFruits.toFixed(0)}</span>
                 </div>
             </div>
 
@@ -151,8 +193,8 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                             <Zap className="w-5 h-5" />
                         </div>
                         <div>
-                            <h3 className="font-semibold text-slate-800">Energy Model</h3>
-                            <p className="text-xs text-slate-400">Efficiency & Cost</p>
+                            <h3 className="font-semibold text-slate-800">{copy.energyModel}</h3>
+                            <p className="text-xs text-slate-400">{copy.efficiencyCost}</p>
                         </div>
                     </div>
                     <div className="text-right">
@@ -174,24 +216,24 @@ const ModelAnalytics = ({ crop, metrics, metricHistory, forecast }: ModelAnalyti
                                 itemStyle={{ fontSize: '12px' }}
                                 formatter={(value: number, name: string) => [value.toFixed(2), name]}
                             />
-                            <Line type="monotone" dataKey="powerKw" stroke="#2563eb" strokeWidth={2} dot={false} name="Electrical demand (kW)" />
-                            <Line type="monotone" dataKey="loadKw" stroke="#60a5fa" strokeWidth={2} dot={false} name="Thermal load (kW)" />
+                            <Line type="monotone" dataKey="powerKw" stroke="#2563eb" strokeWidth={2} dot={false} name={copy.electricalDemand} />
+                            <Line type="monotone" dataKey="loadKw" stroke="#60a5fa" strokeWidth={2} dot={false} name={copy.thermalLoad} />
                         </LineChart>
                     </ResponsiveContainer>
                 </div>
                 <div className="mt-2 flex justify-between text-xs text-slate-500">
-                    <span>Load: <span className="font-medium text-slate-700">{thermalLoadKw.toFixed(1)} kW</span></span>
-                    <span>Est. Cost: <span className="font-medium text-slate-700">{costLabel}</span></span>
+                    <span>{copy.load}: <span className="font-medium text-slate-700">{thermalLoadKw.toFixed(1)} kW</span></span>
+                    <span>{copy.estimatedCost}: <span className="font-medium text-slate-700">{costLabel}</span></span>
                 </div>
                 <div className="mt-3 bg-blue-50 rounded-lg p-3 border border-blue-100">
                     <div className="flex items-center gap-2 mb-1">
                         <TrendingUp className="w-3 h-3 text-blue-600" />
-                        <span className="text-xs font-bold text-blue-800">Optimization Insight</span>
+                        <span className="text-xs font-bold text-blue-800">{copy.optimizationInsight}</span>
                     </div>
                     <p className="text-xs text-blue-700 leading-snug">
                         {energyEfficiency > 3
-                            ? 'High efficiency maintained. Current HVAC response is within the expected control envelope.'
-                            : 'Efficiency drop detected. Check ventilation losses and cooling or heating staging.'}
+                            ? copy.highEfficiency
+                            : copy.efficiencyDrop}
                     </p>
                 </div>
             </div>

--- a/frontend/src/components/ProducePricesPanel.tsx
+++ b/frontend/src/components/ProducePricesPanel.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { ArrowDownRight, ArrowUpRight, Banknote, CalendarDays, LineChart as LineChartIcon, Minus, Sprout } from 'lucide-react';
+import {
+    ArrowDownRight,
+    ArrowUpRight,
+    Banknote,
+    CalendarDays,
+    LineChart as LineChartIcon,
+    Minus,
+    Sprout,
+} from 'lucide-react';
 import {
     CartesianGrid,
     Legend,
@@ -11,11 +19,14 @@ import {
     XAxis,
     YAxis,
 } from 'recharts';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleDate, getIntlLocale, type AppLocale } from '../i18n/locale';
 import type {
     ProducePriceDirection,
     ProducePriceEntry,
     ProducePricesPayload,
 } from '../types';
+import { getProduceDisplayName } from '../utils/displayCopy';
 
 interface ProducePricesPanelProps {
     prices: ProducePricesPayload | null;
@@ -23,42 +34,36 @@ interface ProducePricesPanelProps {
     error: string | null;
 }
 
-const formatKrw = (value: number): string =>
-    new Intl.NumberFormat('en-US', {
+const formatKrw = (locale: AppLocale, value: number): string =>
+    new Intl.NumberFormat(getIntlLocale(locale), {
         style: 'currency',
         currency: 'KRW',
         maximumFractionDigits: 0,
     }).format(value);
 
-const formatCompactKrw = (value: number): string => {
-    if (Math.abs(value) >= 10000) {
-        return `KRW ${(value / 1000).toFixed(0)}k`;
-    }
+const formatCompactKrw = (locale: AppLocale, value: number): string => {
+    const compactValue = new Intl.NumberFormat(getIntlLocale(locale), {
+        notation: 'compact',
+        maximumFractionDigits: 1,
+    }).format(value);
 
-    return `KRW ${Math.round(value / 100) * 100}`;
+    return locale === 'ko' ? `${compactValue}원` : `KRW ${compactValue}`;
 };
 
-const formatSurveyDay = (date: string): string => {
+const formatSurveyDay = (locale: AppLocale, date: string): string => {
     if (!date) {
-        return 'Latest survey';
+        return locale === 'ko' ? '최신 조사일' : 'Latest survey';
     }
 
-    const surveyDate = new Date(`${date}T00:00:00`);
-    if (Number.isNaN(surveyDate.getTime())) {
-        return date;
-    }
-
-    return surveyDate.toLocaleDateString([], { month: 'short', day: 'numeric', weekday: 'short' });
+    return formatLocaleDate(locale, `${date}T00:00:00`, {
+        month: 'short',
+        day: 'numeric',
+        weekday: 'short',
+    });
 };
 
-const formatShortDate = (date: string): string => {
-    const parsed = new Date(`${date}T00:00:00`);
-    if (Number.isNaN(parsed.getTime())) {
-        return date;
-    }
-
-    return parsed.toLocaleDateString([], { month: 'short', day: 'numeric' });
-};
+const formatShortDate = (locale: AppLocale, date: string): string =>
+    formatLocaleDate(locale, `${date}T00:00:00`, { month: 'short', day: 'numeric' });
 
 const coverageRangeLabel = (
     points: ProducePricesPayload['trend']['series'][number]['points'],
@@ -83,70 +88,119 @@ const coverageRangeLabel = (
     return `n=${minCount}-${maxCount}/${windowSize}`;
 };
 
-const directionMeta: Record<
+const getDirectionMeta = (locale: AppLocale): Record<
     ProducePriceDirection,
     {
         label: string;
         Icon: typeof ArrowUpRight;
         accentClassName: string;
     }
-> = {
+> => ({
     up: {
-        label: 'Up',
+        label: locale === 'ko' ? '상승' : 'Up',
         Icon: ArrowUpRight,
         accentClassName: 'border-emerald-100 bg-emerald-50 text-emerald-700',
     },
     down: {
-        label: 'Down',
+        label: locale === 'ko' ? '하락' : 'Down',
         Icon: ArrowDownRight,
         accentClassName: 'border-rose-100 bg-rose-50 text-rose-700',
     },
     flat: {
-        label: 'Flat',
+        label: locale === 'ko' ? '보합' : 'Flat',
         Icon: Minus,
         accentClassName: 'border-slate-100 bg-slate-50 text-slate-600',
     },
+});
+
+const localizeMarketLabel = (marketLabel: string, locale: AppLocale): string => {
+    if (locale !== 'ko') {
+        return marketLabel;
+    }
+
+    const normalizedLabel = marketLabel.toLowerCase();
+    if (normalizedLabel === 'retail') {
+        return '소매';
+    }
+    if (normalizedLabel === 'wholesale') {
+        return '도매';
+    }
+
+    return marketLabel;
+};
+
+const buildProduceSummary = (prices: ProducePricesPayload, locale: AppLocale): string => {
+    const marketLabel = localizeMarketLabel(prices.items[0]?.market_label ?? 'Retail', locale);
+
+    if (locale === 'ko') {
+        return `KAMIS ${formatSurveyDay(locale, prices.source.latest_day)} 기준 주요 시설원예 품목 ${prices.items.length}종의 ${marketLabel} 평균가격입니다. 최근 ${prices.trend.history_days}일 실측과 향후 ${prices.trend.forecast_days}일 평년선(3년·5년·10년)을 함께 비교할 수 있습니다.`;
+    }
+
+    return `KAMIS ${formatSurveyDay(locale, prices.source.latest_day)} snapshot of ${prices.items.length} featured greenhouse produce items in the ${marketLabel.toLowerCase()} market. Compare trailing ${prices.trend.history_days} days of actual prices with forward 3-year, 5-year, and 10-year seasonal normals.`;
 };
 
 const ComparisonChip = ({
     label,
     price,
+    locale,
 }: {
     label: string;
     price: number;
+    locale: AppLocale;
 }) => (
     <div className="rounded-md bg-slate-50 px-2 py-2">
         <div>{label}</div>
-        <div className="mt-1 font-medium text-slate-700">{formatKrw(price)}</div>
+        <div className="mt-1 font-medium text-slate-700">{formatKrw(locale, price)}</div>
     </div>
 );
 
-const ProducePriceCard = ({ item }: { item: ProducePriceEntry }) => {
-    const direction = directionMeta[item.direction];
+const ProducePriceCard = ({
+    item,
+    locale,
+}: {
+    item: ProducePriceEntry;
+    locale: AppLocale;
+}) => {
+    const direction = getDirectionMeta(locale)[item.direction];
 
     return (
         <div className="rounded-lg border border-slate-100 p-3">
             <div className="flex items-start justify-between gap-3">
                 <div>
-                    <div className="text-sm font-semibold text-slate-800">{item.display_name}</div>
+                    <div className="text-sm font-semibold text-slate-800">
+                        {getProduceDisplayName(item.display_name, locale)}
+                    </div>
                     <div className="mt-1 text-[11px] text-slate-500">
-                        {item.source_name} / {item.unit}
+                        {item.source_name} / {item.unit} / {localizeMarketLabel(item.market_label, locale)}
                     </div>
                 </div>
-                <div className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium ${direction.accentClassName}`}>
+                <div
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium ${direction.accentClassName}`}
+                >
                     <direction.Icon className="h-3.5 w-3.5" />
                     <span>{direction.label}</span>
                 </div>
             </div>
             <div className="mt-3 flex items-baseline justify-between gap-3">
-                <div className="text-xl font-bold text-slate-900">{formatKrw(item.current_price_krw)}</div>
+                <div className="text-xl font-bold text-slate-900">
+                    {formatKrw(locale, item.current_price_krw)}
+                </div>
                 <div className="text-xs font-medium text-slate-500">
-                    {item.day_over_day_pct > 0 ? '+' : ''}{item.day_over_day_pct.toFixed(1)}% vs 1d
+                    {item.day_over_day_pct > 0 ? '+' : ''}
+                    {item.day_over_day_pct.toFixed(1)}% {locale === 'ko' ? '전일 대비' : 'vs 1d'}
                 </div>
             </div>
             <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-500">
-                <ComparisonChip label="1d ago" price={item.previous_day_price_krw} />
-                <ComparisonChip label="1m ago" price={item.month_ago_price_krw} />
+                <ComparisonChip
+                    label={locale === 'ko' ? '전일' : '1d ago'}
+                    price={item.previous_day_price_krw}
+                    locale={locale}
+                />
+                <ComparisonChip
+                    label={locale === 'ko' ? '1개월 전' : '1m ago'}
+                    price={item.month_ago_price_krw}
+                    locale={locale}
+                />
             </div>
         </div>
     );
@@ -154,12 +208,51 @@ const ProducePriceCard = ({ item }: { item: ProducePriceEntry }) => {
 
 const TrendChart = ({
     prices,
+    locale,
 }: {
     prices: ProducePricesPayload;
+    locale: AppLocale;
 }) => {
     const [selectedKey, setSelectedKey] = useState<string | null>(null);
     const availableSeries = prices.trend.series;
     const unavailableSeries = prices.trend.unavailable_series;
+    const copy = locale === 'ko'
+        ? {
+            unavailable: '현재 주요 품목 목록에 대한 KAMIS 추세선 데이터를 불러올 수 없습니다.',
+            title: '최근 2주 실측 vs 평년 추세선',
+            description: `상단 카드는 최신 KAMIS 조사 스냅샷이고, 차트는 최근 ${prices.trend.history_days}일 소매 평균가격 실측과 향후 ${prices.trend.forecast_days}일 평년선(3년·5년·10년)을 겹쳐 보여줍니다.`,
+            reference: '기준일',
+            noData: '데이터 없음',
+            actual: '실측 평균',
+            normal3: '3년 평년',
+            normal5: '5년 평년',
+            normal10: '10년 평년',
+            ref: '기준',
+            seriesWindow: '표시 구간',
+            futureCoverage: '미래 표본 범위',
+            windowLabel: (historyDays: number, forecastDays: number) =>
+                `실측 ${historyDays}일 + 향후 ${forecastDays}일 평년선`,
+            unavailablePrefix: '다음 품목은 추세선이 비활성화되어 있습니다',
+            unavailableSuffix: '카드 스냅샷은 계속 실시간으로 표시됩니다.',
+        }
+        : {
+            unavailable: 'KAMIS trend overlay is unavailable for the current featured produce list.',
+            title: '2-week trend vs seasonal normals',
+            description: `Cards above use the latest KAMIS item snapshot. The chart history line uses KAMIS retail average prices for the trailing ${prices.trend.history_days} days, while forward lines use matching calendar dates averaged across the prior 3, 5, and 10 years.`,
+            reference: 'Reference',
+            noData: 'No data',
+            actual: 'Actual avg',
+            normal3: '3y normal',
+            normal5: '5y normal',
+            normal10: '10y normal',
+            ref: 'Ref',
+            seriesWindow: 'Series window',
+            futureCoverage: 'Future coverage',
+            windowLabel: (historyDays: number, forecastDays: number) =>
+                `${historyDays}d actual + ${forecastDays}d forward normals`,
+            unavailablePrefix: 'Trend overlay is unavailable for',
+            unavailableSuffix: 'Snapshot cards remain live even when historical enrichment is missing.',
+        };
 
     const selectedSeries =
         availableSeries.find((series) => series.key === selectedKey) ?? availableSeries[0] ?? null;
@@ -167,7 +260,7 @@ const TrendChart = ({
     if (!selectedSeries) {
         return (
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-                KAMIS trend overlay is unavailable for the current featured produce list.
+                {copy.unavailable}
             </div>
         );
     }
@@ -178,18 +271,16 @@ const TrendChart = ({
                 <div>
                     <div className="flex items-center gap-2 text-sm font-semibold text-slate-800">
                         <LineChartIcon className="h-4 w-4 text-emerald-600" />
-                        <span>2-week trend vs seasonal normals</span>
+                        <span>{copy.title}</span>
                     </div>
                     <p className="mt-1 text-[11px] leading-relaxed text-slate-500">
-                        Cards above use the latest KAMIS item snapshot. The chart history line uses KAMIS retail
-                        average prices for the trailing {prices.trend.history_days} days, while forward lines use
-                        matching calendar dates averaged across the prior 3, 5, and 10 years.
+                        {copy.description}
                     </p>
                 </div>
                 <div className="rounded-2xl bg-white px-3 py-2 text-right text-[11px] text-slate-500 shadow-sm">
-                    <div>Reference</div>
+                    <div>{copy.reference}</div>
                     <div className="mt-1 font-semibold text-slate-700">
-                        {formatSurveyDay(prices.trend.reference_date)}
+                        {formatSurveyDay(locale, prices.trend.reference_date)}
                     </div>
                 </div>
             </div>
@@ -206,7 +297,7 @@ const TrendChart = ({
                                 : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-800'
                         }`}
                     >
-                        {series.display_name}
+                        {getProduceDisplayName(series.display_name, locale)}
                     </button>
                 ))}
             </div>
@@ -217,7 +308,7 @@ const TrendChart = ({
                         <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                         <XAxis
                             dataKey="date"
-                            tickFormatter={formatShortDate}
+                            tickFormatter={(value) => formatShortDate(locale, String(value))}
                             stroke="#94a3b8"
                             tick={{ fontSize: 11 }}
                             minTickGap={16}
@@ -225,8 +316,8 @@ const TrendChart = ({
                         <YAxis
                             stroke="#94a3b8"
                             tick={{ fontSize: 11 }}
-                            tickFormatter={(value: number) => formatCompactKrw(value)}
-                            width={64}
+                            tickFormatter={(value: number) => formatCompactKrw(locale, value)}
+                            width={72}
                         />
                         <Tooltip
                             contentStyle={{
@@ -235,24 +326,24 @@ const TrendChart = ({
                                 borderRadius: '10px',
                                 boxShadow: '0 12px 32px -20px rgba(15, 23, 42, 0.55)',
                             }}
-                            labelFormatter={(value) => formatSurveyDay(String(value))}
+                            labelFormatter={(value) => formatSurveyDay(locale, String(value))}
                             formatter={(value, name, item) => {
                                 if (typeof value !== 'number') {
-                                    return ['No data', name];
+                                    return [copy.noData, name];
                                 }
 
                                 const point = item?.payload as ProducePricesPayload['trend']['series'][number]['points'][number] | undefined;
-                                if (name === '3y normal') {
-                                    return [formatKrw(value), `3y normal (n=${point?.normal_3y_sample_count ?? 0})`];
+                                if (name === copy.normal3) {
+                                    return [formatKrw(locale, value), `${copy.normal3} (n=${point?.normal_3y_sample_count ?? 0})`];
                                 }
-                                if (name === '5y normal') {
-                                    return [formatKrw(value), `5y normal (n=${point?.normal_5y_sample_count ?? 0})`];
+                                if (name === copy.normal5) {
+                                    return [formatKrw(locale, value), `${copy.normal5} (n=${point?.normal_5y_sample_count ?? 0})`];
                                 }
-                                if (name === '10y normal') {
-                                    return [formatKrw(value), `10y normal (n=${point?.normal_10y_sample_count ?? 0})`];
+                                if (name === copy.normal10) {
+                                    return [formatKrw(locale, value), `${copy.normal10} (n=${point?.normal_10y_sample_count ?? 0})`];
                                 }
 
-                                return [formatKrw(value), name];
+                                return [formatKrw(locale, value), name];
                             }}
                         />
                         <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }} />
@@ -260,12 +351,12 @@ const TrendChart = ({
                             x={prices.trend.reference_date}
                             stroke="#94a3b8"
                             strokeDasharray="4 4"
-                            label={{ value: 'Ref', position: 'top', fill: '#475569', fontSize: 11 }}
+                            label={{ value: copy.ref, position: 'top', fill: '#475569', fontSize: 11 }}
                         />
                         <Line
                             type="monotone"
                             dataKey="actual_price_krw"
-                            name="Actual avg"
+                            name={copy.actual}
                             stroke="#0f766e"
                             strokeWidth={3}
                             dot={false}
@@ -275,7 +366,7 @@ const TrendChart = ({
                         <Line
                             type="monotone"
                             dataKey="normal_3y_price_krw"
-                            name="3y normal"
+                            name={copy.normal3}
                             stroke="#84cc16"
                             strokeWidth={2}
                             strokeDasharray="4 4"
@@ -286,7 +377,7 @@ const TrendChart = ({
                         <Line
                             type="monotone"
                             dataKey="normal_5y_price_krw"
-                            name="5y normal"
+                            name={copy.normal5}
                             stroke="#f59e0b"
                             strokeWidth={2}
                             strokeDasharray="6 4"
@@ -297,7 +388,7 @@ const TrendChart = ({
                         <Line
                             type="monotone"
                             dataKey="normal_10y_price_krw"
-                            name="10y normal"
+                            name={copy.normal10}
                             stroke="#6366f1"
                             strokeWidth={2}
                             strokeDasharray="8 4"
@@ -311,13 +402,13 @@ const TrendChart = ({
 
             <div className="mt-3 grid grid-cols-1 gap-2 text-[11px] text-slate-500 sm:grid-cols-2">
                 <div className="rounded-md bg-white px-3 py-2 shadow-sm">
-                    <div className="font-medium text-slate-700">Series window</div>
+                    <div className="font-medium text-slate-700">{copy.seriesWindow}</div>
                     <div className="mt-1">
-                        {selectedSeries.history_days}d actual + {selectedSeries.forecast_days}d forward normals
+                        {copy.windowLabel(selectedSeries.history_days, selectedSeries.forecast_days)}
                     </div>
                 </div>
                 <div className="rounded-md bg-white px-3 py-2 shadow-sm">
-                    <div className="font-medium text-slate-700">Future coverage</div>
+                    <div className="font-medium text-slate-700">{copy.futureCoverage}</div>
                     <div className="mt-1">
                         3y {coverageRangeLabel(selectedSeries.points, 'normal_3y_sample_count', 3)} / 5y {coverageRangeLabel(selectedSeries.points, 'normal_5y_sample_count', 5)} / 10y {coverageRangeLabel(selectedSeries.points, 'normal_10y_sample_count', 10)}
                     </div>
@@ -326,68 +417,90 @@ const TrendChart = ({
 
             {unavailableSeries.length > 0 ? (
                 <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">
-                    Trend overlay is unavailable for {unavailableSeries.map((series) => series.display_name).join(', ')}.
-                    Snapshot cards remain live even when historical enrichment is missing.
+                    {copy.unavailablePrefix} {unavailableSeries.map((series) => getProduceDisplayName(series.display_name, locale)).join(', ')}. {copy.unavailableSuffix}
                 </div>
             ) : null}
         </div>
     );
 };
 
-const ProducePricesPanel = ({ prices, loading, error }: ProducePricesPanelProps) => (
-    <div className="flex h-full flex-col rounded-xl border border-slate-100 bg-white p-5 shadow-sm">
-        <div className="mb-4 flex items-start justify-between gap-3">
-            <div>
-                <div className="flex items-center gap-2 text-slate-800">
-                    <Banknote className="h-5 w-5 text-emerald-600" />
-                    <h3 className="font-semibold">Live Produce Prices</h3>
+const ProducePricesPanel = ({ prices, loading, error }: ProducePricesPanelProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: '실시간 농산물 가격',
+            subtitle: '주요 시설원예 품목 스냅샷과 2주 평년 추세선',
+            loading: '실시간 농산물 가격을 불러오는 중...',
+            unavailable: '농산물 가격 패널을 불러올 수 없습니다',
+            retail: '소매',
+        }
+        : {
+            title: 'Live Produce Prices',
+            subtitle: 'Curated greenhouse produce snapshot with 2-week KAMIS seasonal overlays',
+            loading: 'Loading live produce prices...',
+            unavailable: 'Produce price panel is unavailable',
+            retail: 'Retail',
+        };
+
+    return (
+        <div className="flex h-full flex-col rounded-xl border border-slate-100 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-start justify-between gap-3">
+                <div>
+                    <div className="flex items-center gap-2 text-slate-800">
+                        <Banknote className="h-5 w-5 text-emerald-600" />
+                        <h3 className="font-semibold">{copy.title}</h3>
+                    </div>
+                    <p className="mt-1 text-xs text-slate-400">{copy.subtitle}</p>
                 </div>
-                <p className="mt-1 text-xs text-slate-400">Curated greenhouse produce snapshot with 2-week KAMIS seasonal overlays</p>
+                <div className="rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-medium text-emerald-700">
+                    KAMIS
+                </div>
             </div>
-            <div className="rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-medium text-emerald-700">
-                KAMIS
-            </div>
+
+            {loading ? (
+                <div className="rounded-lg bg-slate-50 p-4 text-sm text-slate-500">{copy.loading}</div>
+            ) : error ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                    {copy.unavailable}: {error}
+                </div>
+            ) : prices ? (
+                <div className="flex h-full flex-col space-y-4">
+                    <div className="rounded-lg bg-gradient-to-br from-emerald-50 to-lime-50 p-4">
+                        <div className="flex items-start justify-between gap-3">
+                            <div>
+                                <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
+                                    <Sprout className="h-3.5 w-3.5 text-emerald-600" />
+                                    <span>{prices.source.provider} {prices.source.endpoint}</span>
+                                </div>
+                                <p className="mt-2 text-sm leading-relaxed text-slate-700">
+                                    {buildProduceSummary(prices, locale)}
+                                </p>
+                            </div>
+                            <div className="rounded-2xl bg-white/80 px-3 py-2 text-right text-xs text-slate-500 shadow-sm">
+                                <div className="flex items-center justify-end gap-1">
+                                    <CalendarDays className="h-3.5 w-3.5 text-emerald-600" />
+                                    <span>{formatSurveyDay(locale, prices.source.latest_day)}</span>
+                                </div>
+                                <div className="mt-1">
+                                    {localizeMarketLabel(prices.items[0]?.market_label ?? copy.retail, locale)}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(250px,0.95fr)] lg:items-start">
+                        <TrendChart prices={prices} locale={locale} />
+
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                            {prices.items.map((item) => (
+                                <ProducePriceCard key={item.key} item={item} locale={locale} />
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            ) : null}
         </div>
-
-        {loading ? (
-            <div className="rounded-lg bg-slate-50 p-4 text-sm text-slate-500">Loading live produce prices...</div>
-        ) : error ? (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-                Produce price panel is unavailable: {error}
-            </div>
-        ) : prices ? (
-            <div className="flex h-full flex-col space-y-4">
-                <div className="rounded-lg bg-gradient-to-br from-emerald-50 to-lime-50 p-4">
-                    <div className="flex items-start justify-between gap-3">
-                        <div>
-                            <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
-                                <Sprout className="h-3.5 w-3.5 text-emerald-600" />
-                                <span>{prices.source.provider} {prices.source.endpoint}</span>
-                            </div>
-                            <p className="mt-2 text-sm leading-relaxed text-slate-700">{prices.summary}</p>
-                        </div>
-                        <div className="rounded-2xl bg-white/80 px-3 py-2 text-right text-xs text-slate-500 shadow-sm">
-                            <div className="flex items-center justify-end gap-1">
-                                <CalendarDays className="h-3.5 w-3.5 text-emerald-600" />
-                                <span>{formatSurveyDay(prices.source.latest_day)}</span>
-                            </div>
-                            <div className="mt-1">{prices.items[0]?.market_label ?? 'Retail'}</div>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(250px,0.95fr)] lg:items-start">
-                    <TrendChart prices={prices} />
-
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-1">
-                        {prices.items.map((item) => (
-                            <ProducePriceCard key={item.key} item={item} />
-                        ))}
-                    </div>
-                </div>
-            </div>
-        ) : null}
-    </div>
-);
+    );
+};
 
 export default ProducePricesPanel;

--- a/frontend/src/components/RTROutlookPanel.tsx
+++ b/frontend/src/components/RTROutlookPanel.tsx
@@ -1,5 +1,8 @@
 import { CalendarDays, Leaf, Sun, Target, Thermometer } from 'lucide-react';
 import type { CropType, RtrProfile, SensorData, TemperatureSettings, WeatherOutlook } from '../types';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleDate } from '../i18n/locale';
+import { getCropLabel, getWeatherLabel } from '../utils/displayCopy';
 import {
     getRtrProfile,
     buildRTRForecastTargets,
@@ -19,26 +22,57 @@ interface RTROutlookPanelProps {
     profileError: string | null;
 }
 
-const formatForecastLabel = (date: string): string =>
-    new Date(date).toLocaleDateString([], { month: 'short', day: 'numeric', weekday: 'short' });
+const getCalibrationModeLabel = (mode: RtrProfile['calibration']['mode'], locale: 'en' | 'ko'): string => {
+    if (locale === 'ko') {
+        if (mode === 'fitted') return '하우스 보정';
+        if (mode === 'insufficient-data') return '기준선 유지(데이터 부족)';
+        return '기준선';
+    }
 
-const BALANCE_COPY = {
-    balanced: {
-        badge: 'Near RTR line',
-        tone: 'bg-emerald-100 text-emerald-700',
-        description: 'Temperature and light are moving together in a balanced range.',
-    },
-    'warm-for-light': {
-        badge: 'Warm for light',
-        tone: 'bg-rose-100 text-rose-700',
-        description: 'Temperature is running ahead of the available light, which can push the crop more generative.',
-    },
-    'cool-for-light': {
-        badge: 'Cool for light',
-        tone: 'bg-sky-100 text-sky-700',
-        description: 'Light is strong relative to the current temperature, which can push the crop more vegetative.',
-    },
-} as const;
+    return mode;
+};
+
+const getLocalizedStrategyLabel = (profile: RtrProfile, locale: 'en' | 'ko'): string => {
+    if (locale !== 'ko') {
+        return profile.strategyLabel;
+    }
+
+    const cropLabel = getCropLabel(profile.crop, locale);
+    if (profile.calibration.mode === 'fitted') {
+        return `${cropLabel} 하우스 보정 RTR 선`;
+    }
+    if (profile.calibration.mode === 'insufficient-data') {
+        return `${cropLabel} RTR 기준선(데이터 보강 필요)`;
+    }
+    return `${cropLabel} RTR 기준선`;
+};
+
+const getLocalizedSourceNote = (profile: RtrProfile, locale: 'en' | 'ko'): string => {
+    if (locale !== 'ko') {
+        return profile.sourceNote;
+    }
+
+    const { calibration } = profile;
+    if (calibration.mode === 'fitted') {
+        if (calibration.selectionSource === 'curated-windows') {
+            return `고생산 구간 ${calibration.windowCount ?? 0}개에서 quality-filtered 일별 RTR 포인트 ${calibration.sampleDays}개를 사용해 보정한 하우스 맞춤 RTR 선입니다.`;
+        }
+        return `이 하우스의 quality-filtered 일별 RTR 포인트 ${calibration.sampleDays}개를 사용해 보정한 하우스 맞춤 RTR 선입니다.`;
+    }
+
+    if (calibration.mode === 'insufficient-data') {
+        if (calibration.selectionSource === 'curated-windows') {
+            return '고생산 구간은 설정되어 있지만 보정에 충분한 일별 RTR 포인트가 아직 부족해 기준선을 유지합니다.';
+        }
+        return '하우스별 데이터를 더 확보하기 전까지는 RTR 기준선을 유지합니다.';
+    }
+
+    if (profile.crop === 'Tomato') {
+        return 'WUR RTR 프레이밍과 TomatoesNZ 예시 그래프를 기준으로 한 토마토 RTR 기준선입니다. 하우스별 고생산 구간이 확보되면 다시 보정하세요.';
+    }
+
+    return '오이의 24시간 평균온도 가이드를 기준으로 한 RTR 기준선입니다. 하우스별 고생산 구간이 확보되면 다시 보정하세요.';
+};
 
 const RTROutlookPanel = ({
     crop,
@@ -52,6 +86,92 @@ const RTROutlookPanel = ({
     profileLoading,
     profileError,
 }: RTROutlookPanelProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: 'RTR 모니터',
+            subtitle: `${getCropLabel(crop, locale)}의 최근 24시간 광-온도 균형`,
+            profileLoading: 'RTR 프로파일을 불러오는 중...',
+            rolling: '최근 24시간 RTR',
+            vsProfile: '프로파일 기준선 대비',
+            coverage: '윈도우 커버리지',
+            radiationSum: '광량 합계',
+            meanTemp: '24시간 평균 온도',
+            exampleTarget: '예시 목표',
+            steeringPlan: '3일 RTR 제어 계획',
+            forecastLoading: '대구 복사 예보를 불러오는 중...',
+            forecastWaiting: '복사량 데이터가 들어오면 RTR 목표가 계산됩니다.',
+            weatherUnavailable: '날씨 기반 RTR 예측을 불러올 수 없습니다',
+            referenceLine: '기준식',
+            profileMode: '프로파일 모드',
+            selectionPath: '선정 경로',
+            fitQuality: '적합도',
+            currentControlWindow: '현재 제어 범위',
+            profileEndpointUnavailable: 'RTR 프로파일 엔드포인트를 사용할 수 없어 내장 기준선을 사용합니다',
+            selectionCurated: '선별 윈도우',
+            selectionFallback: '휴리스틱 fallback',
+            badgeFitted: '하우스 보정',
+            badgeBaselineNeedMore: '기준선 (데이터 부족)',
+            badgeBaseline: '기준선',
+            balanced: {
+                badge: 'RTR 기준선 근처',
+                tone: 'bg-emerald-100 text-emerald-700',
+                description: '온도와 광이 비교적 균형 있게 움직이고 있습니다.',
+            },
+            'warm-for-light': {
+                badge: '광량 대비 고온',
+                tone: 'bg-rose-100 text-rose-700',
+                description: '현재 광량보다 온도가 앞서 있어 작물이 더 생식생장 쪽으로 기울 수 있습니다.',
+            },
+            'cool-for-light': {
+                badge: '광량 대비 저온',
+                tone: 'bg-sky-100 text-sky-700',
+                description: '현재 온도보다 광이 강해 작물이 더 영양생장 쪽으로 기울 수 있습니다.',
+            },
+        }
+        : {
+            title: 'RTR Monitor',
+            subtitle: `Rolling 24 h radiation-to-temperature balance for ${crop}`,
+            profileLoading: 'Loading RTR profile...',
+            rolling: 'Rolling 24 h RTR',
+            vsProfile: 'vs profile line',
+            coverage: 'Window coverage',
+            radiationSum: 'Radiation sum',
+            meanTemp: '24 h mean temp',
+            exampleTarget: 'Example target',
+            steeringPlan: '3-day RTR steering plan',
+            forecastLoading: 'Loading Daegu radiation forecast...',
+            forecastWaiting: 'Forecast-linked RTR targets are waiting for radiation data.',
+            weatherUnavailable: 'Weather-linked RTR forecast is unavailable',
+            referenceLine: 'Reference line',
+            profileMode: 'Profile mode',
+            selectionPath: 'Selection path',
+            fitQuality: 'Fit quality',
+            currentControlWindow: 'Current control window',
+            profileEndpointUnavailable: 'RTR profile endpoint unavailable, using bundled baseline',
+            selectionCurated: 'curated windows',
+            selectionFallback: 'heuristic fallback',
+            badgeFitted: 'House-fit',
+            badgeBaselineNeedMore: 'Baseline (needs more data)',
+            badgeBaseline: 'Baseline',
+            balanced: {
+                badge: 'Near RTR line',
+                tone: 'bg-emerald-100 text-emerald-700',
+                description: 'Temperature and light are moving together in a balanced range.',
+            },
+            'warm-for-light': {
+                badge: 'Warm for light',
+                tone: 'bg-rose-100 text-rose-700',
+                description: 'Temperature is running ahead of the available light, which can push the crop more generative.',
+            },
+            'cool-for-light': {
+                badge: 'Cool for light',
+                tone: 'bg-sky-100 text-sky-700',
+                description: 'Light is strong relative to the current temperature, which can push the crop more vegetative.',
+            },
+        };
+    const formatForecastLabel = (date: string): string =>
+        formatLocaleDate(locale, `${date}T00:00:00`, { month: 'short', day: 'numeric', weekday: 'short' });
     const effectiveProfile = getRtrProfile(crop, profile);
     const liveSnapshot = buildRTRLiveSnapshot(currentData, history, crop, effectiveProfile);
     const forecastTargets = buildRTRForecastTargets(
@@ -59,15 +179,18 @@ const RTROutlookPanel = ({
         crop,
         effectiveProfile,
     );
-    const balanceCopy = BALANCE_COPY[liveSnapshot.balanceState];
+    const balanceCopy = copy[liveSnapshot.balanceState];
+    const localizedStrategyLabel = getLocalizedStrategyLabel(effectiveProfile, locale);
+    const localizedSourceNote = getLocalizedSourceNote(effectiveProfile, locale);
+    const calibrationModeLabel = getCalibrationModeLabel(effectiveProfile.calibration.mode, locale);
     const profileBadge = effectiveProfile.calibration.mode === 'fitted'
-        ? `House-fit (${effectiveProfile.calibration.sampleDays} d)`
+        ? `${copy.badgeFitted} (${effectiveProfile.calibration.sampleDays}${locale === 'ko' ? '일' : ' d'})`
         : effectiveProfile.calibration.mode === 'insufficient-data'
-            ? 'Baseline (needs more data)'
-            : 'Baseline';
+            ? copy.badgeBaselineNeedMore
+            : copy.badgeBaseline;
     const selectionLabel = effectiveProfile.calibration.selectionSource === 'curated-windows'
-        ? `curated windows (${effectiveProfile.calibration.windowCount ?? 0})`
-        : 'heuristic fallback';
+        ? `${copy.selectionCurated} (${effectiveProfile.calibration.windowCount ?? 0})`
+        : copy.selectionFallback;
 
     return (
         <div className="flex h-full flex-col rounded-xl border border-slate-100 bg-white p-5 shadow-sm">
@@ -75,10 +198,10 @@ const RTROutlookPanel = ({
                 <div>
                     <div className="flex items-center gap-2 text-slate-800">
                         <Target className="h-5 w-5 text-emerald-600" />
-                        <h3 className="font-semibold">RTR Monitor</h3>
+                        <h3 className="font-semibold">{copy.title}</h3>
                     </div>
                     <p className="mt-1 text-xs text-slate-400">
-                        Rolling 24 h radiation-to-temperature balance for {crop}
+                        {copy.subtitle}
                     </p>
                 </div>
                 <div className="flex flex-col items-end gap-1">
@@ -86,7 +209,7 @@ const RTROutlookPanel = ({
                         {profileBadge}
                     </div>
                     {profileLoading ? (
-                        <div className="text-[11px] text-slate-400">Loading RTR profile...</div>
+                        <div className="text-[11px] text-slate-400">{copy.profileLoading}</div>
                     ) : null}
                 </div>
             </div>
@@ -97,21 +220,21 @@ const RTROutlookPanel = ({
                         <div>
                             <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                                 <Leaf className="h-3.5 w-3.5 text-emerald-600" />
-                                <span>Rolling 24 h RTR</span>
+                                <span>{copy.rolling}</span>
                             </div>
                             <div className="mt-2 flex items-baseline gap-2 text-slate-900">
                                 <span className="text-3xl font-bold">{liveSnapshot.deltaTempC.toFixed(1)}&deg;C</span>
-                                <span className="text-sm text-slate-500">vs profile line</span>
+                                <span className="text-sm text-slate-500">{copy.vsProfile}</span>
                             </div>
                             <p className="mt-2 text-sm font-medium text-slate-700">{balanceCopy.description}</p>
-                            <p className="mt-2 text-xs leading-relaxed text-slate-500">{effectiveProfile.sourceNote}</p>
+                            <p className="mt-2 text-xs leading-relaxed text-slate-500">{localizedSourceNote}</p>
                         </div>
                         <div className={`rounded-2xl px-3 py-2 text-right text-xs font-medium shadow-sm ${balanceCopy.tone}`}>
                             {balanceCopy.badge}
                         </div>
                     </div>
                     <div className="mt-3 text-xs text-slate-500">
-                        Window coverage {liveSnapshot.windowHours.toFixed(1)} h / 24 h
+                        {copy.coverage} {liveSnapshot.windowHours.toFixed(1)} h / 24 h
                         <span className="ml-2 font-medium text-slate-700">{liveSnapshot.coveragePct.toFixed(0)}%</span>
                     </div>
                 </div>
@@ -120,7 +243,7 @@ const RTROutlookPanel = ({
                     <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
                         <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                             <Sun className="h-4 w-4 text-amber-500" />
-                            <span>Radiation sum</span>
+                            <span>{copy.radiationSum}</span>
                         </div>
                         <div className="mt-2 text-lg font-semibold text-slate-800">
                             {liveSnapshot.radiationSumMjM2D.toFixed(1)} MJ m⁻²
@@ -132,13 +255,13 @@ const RTROutlookPanel = ({
                     <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
                         <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                             <Thermometer className="h-4 w-4 text-orange-500" />
-                            <span>24 h mean temp</span>
+                            <span>{copy.meanTemp}</span>
                         </div>
                         <div className="mt-2 text-lg font-semibold text-slate-800">
                             {liveSnapshot.averageTempC.toFixed(1)}&deg;C
                         </div>
                         <div className="mt-1 text-xs text-slate-500">
-                            Example target {liveSnapshot.targetTempC.toFixed(1)}&deg;C
+                            {copy.exampleTarget} {liveSnapshot.targetTempC.toFixed(1)}&deg;C
                         </div>
                     </div>
                 </div>
@@ -146,12 +269,12 @@ const RTROutlookPanel = ({
                 <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
                     <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                         <CalendarDays className="h-4 w-4 text-slate-500" />
-                        <span>3-day RTR steering plan</span>
+                        <span>{copy.steeringPlan}</span>
                     </div>
                     <div className="mt-3 grid gap-2 sm:grid-cols-3 xl:grid-cols-1">
                         {loading ? (
                             <div className="rounded-md bg-white px-3 py-3 text-sm text-slate-500">
-                                Loading Daegu radiation forecast...
+                                {copy.forecastLoading}
                             </div>
                         ) : forecastTargets.length > 0 ? (
                             forecastTargets.map((day) => (
@@ -159,7 +282,7 @@ const RTROutlookPanel = ({
                                     <div className="flex items-start justify-between gap-3">
                                         <div>
                                             <div className="text-sm font-semibold text-slate-800">{formatForecastLabel(day.date)}</div>
-                                            <div className="mt-1 text-xs text-slate-500">{day.weatherLabel}</div>
+                                            <div className="mt-1 text-xs text-slate-500">{getWeatherLabel(undefined, day.weatherLabel, locale)}</div>
                                         </div>
                                         <div className="text-right">
                                             <div className="text-sm font-semibold text-slate-800">
@@ -174,39 +297,39 @@ const RTROutlookPanel = ({
                             ))
                         ) : (
                             <div className="rounded-md bg-white px-3 py-3 text-sm text-slate-500">
-                                Forecast-linked RTR targets are waiting for radiation data.
+                                {copy.forecastWaiting}
                             </div>
                         )}
                     </div>
                     {error ? (
                         <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-xs text-amber-800">
-                            Weather-linked RTR forecast is unavailable: {error}
+                            {copy.weatherUnavailable}: {error}
                         </div>
                     ) : null}
                 </div>
 
                 <div className="rounded-lg border border-dashed border-slate-200 px-3 py-3 text-xs leading-relaxed text-slate-500">
-                    <div className="font-medium text-slate-700">{effectiveProfile.strategyLabel}</div>
+                    <div className="font-medium text-slate-700">{localizedStrategyLabel}</div>
                     <div className="mt-1">
-                        Reference line: T24 = {effectiveProfile.baseTempC.toFixed(1)} + {effectiveProfile.slopeCPerMjM2.toFixed(2)} x radiation sum (MJ m⁻² d⁻¹).
+                        {copy.referenceLine}: T24 = {effectiveProfile.baseTempC.toFixed(1)} + {effectiveProfile.slopeCPerMjM2.toFixed(2)} x radiation sum (MJ m⁻² d⁻¹).
                     </div>
                     <div className="mt-1">
-                        Profile mode: {effectiveProfile.calibration.mode}, sample days: {effectiveProfile.calibration.sampleDays}.
+                        {copy.profileMode}: {calibrationModeLabel}, {locale === 'ko' ? '샘플 일수' : 'sample days'} {effectiveProfile.calibration.sampleDays}.
                     </div>
                     <div className="mt-1">
-                        Selection path: {selectionLabel}.
+                        {copy.selectionPath}: {selectionLabel}.
                     </div>
                     {effectiveProfile.calibration.rSquared !== null ? (
                         <div className="mt-1">
-                            Fit quality: R² {effectiveProfile.calibration.rSquared.toFixed(2)}, MAE {effectiveProfile.calibration.meanAbsoluteErrorC?.toFixed(2)}°C.
+                            {copy.fitQuality}: R² {effectiveProfile.calibration.rSquared.toFixed(2)}, MAE {effectiveProfile.calibration.meanAbsoluteErrorC?.toFixed(2)}°C.
                         </div>
                     ) : null}
                     <div className="mt-1">
-                        Current control window: {temperatureSettings.heating}&deg;C to {temperatureSettings.cooling}&deg;C.
+                        {copy.currentControlWindow}: {temperatureSettings.heating}&deg;C to {temperatureSettings.cooling}&deg;C.
                     </div>
                     {profileError ? (
                         <div className="mt-1 text-amber-700">
-                            RTR profile endpoint unavailable, using bundled baseline: {profileError}
+                            {copy.profileEndpointUnavailable}: {profileError}
                         </div>
                     ) : null}
                 </div>

--- a/frontend/src/components/SensorCard.tsx
+++ b/frontend/src/components/SensorCard.tsx
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
+import { useLocale } from '../i18n/LocaleProvider';
 import { formatMetricValue } from '../utils/formatValue';
 
 interface SensorCardProps {
@@ -15,6 +16,7 @@ interface SensorCardProps {
 }
 
 const SensorCard = ({ title, value, unit, subValue, icon: Icon, color, trend, idealRange, className, fractionDigits }: SensorCardProps) => {
+    const { locale } = useLocale();
     const displayValue = typeof value === 'number'
         ? formatMetricValue(value, fractionDigits)
         : value;
@@ -42,7 +44,7 @@ const SensorCard = ({ title, value, unit, subValue, icon: Icon, color, trend, id
                 {idealRange && (
                     <p className="text-xs text-slate-400 mt-2 flex items-start gap-1 leading-snug">
                         <span className="w-1.5 h-1.5 rounded-full bg-green-500"></span>
-                        Target band: {idealRange}
+                        {locale === 'ko' ? `목표 범위: ${idealRange}` : `Target band: ${idealRange}`}
                     </p>
                 )}
             </div>

--- a/frontend/src/components/TimeSeriesChart.tsx
+++ b/frontend/src/components/TimeSeriesChart.tsx
@@ -1,5 +1,7 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { ReactNode } from "react";
+import { useLocale } from "../i18n/LocaleProvider";
+import { formatLocaleDateTime, formatLocaleTime } from "../i18n/locale";
 
 interface DataKey {
     key: string;
@@ -24,6 +26,7 @@ const TimeSeriesChart = <T extends { timestamp?: number }>({
     icon,
     height = 240,
 }: TimeSeriesChartProps<T>) => {
+    const { locale } = useLocale();
     // Helper to get nested value like "env.temperature"
     const getNestedValue = (obj: Record<string, unknown>, path: string): unknown => {
         return path.split('.').reduce<unknown>((acc, part) => {
@@ -41,7 +44,7 @@ const TimeSeriesChart = <T extends { timestamp?: number }>({
                     {icon}
                     <span className="font-medium">{title}</span>
                 </div>
-                <p>Waiting for data...</p>
+                <p>{locale === 'ko' ? '데이터를 기다리는 중...' : 'Waiting for data...'}</p>
             </div>
         );
     }
@@ -84,7 +87,7 @@ const TimeSeriesChart = <T extends { timestamp?: number }>({
                         <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
                         <XAxis
                             dataKey="timestamp"
-                            tickFormatter={(t) => t ? new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''}
+                            tickFormatter={(t) => t ? formatLocaleTime(locale, t, { hour: '2-digit', minute: '2-digit' }) : ''}
                             stroke="#94a3b8"
                             tick={{ fontSize: 11 }}
                         />
@@ -96,7 +99,7 @@ const TimeSeriesChart = <T extends { timestamp?: number }>({
                                 borderRadius: '8px',
                                 boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
                             }}
-                            labelFormatter={(t) => t ? new Date(t).toLocaleString() : ''}
+                            labelFormatter={(t) => t ? formatLocaleDateTime(locale, t) : ''}
                         />
                         <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }} />
                         {dataKeys.map(({ key, name, color }) => (

--- a/frontend/src/components/WeatherOutlookPanel.tsx
+++ b/frontend/src/components/WeatherOutlookPanel.tsx
@@ -1,4 +1,7 @@
 import { CloudRain, CloudSun, MapPinned, Thermometer, Wind } from 'lucide-react';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleDate, formatLocaleDateTime } from '../i18n/locale';
+import { getCountryLabel, getWeatherLabel } from '../utils/displayCopy';
 import type { WeatherOutlook } from '../types';
 
 interface WeatherOutlookPanelProps {
@@ -7,18 +10,58 @@ interface WeatherOutlookPanelProps {
     error: string | null;
 }
 
-const formatForecastLabel = (date: string): string =>
-    new Date(date).toLocaleDateString([], { month: 'short', day: 'numeric', weekday: 'short' });
+const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelProps) => {
+    const { locale } = useLocale();
+    const copy = locale === 'ko'
+        ? {
+            title: '대구 실시간 날씨',
+            subtitle: '현재 상태와 3일 전망',
+            loading: '대구 실시간 날씨를 불러오는 중...',
+            unavailable: '날씨 패널을 불러올 수 없습니다',
+            feelsLike: '체감',
+            humidityClouds: '습도 / 운량',
+            windRain: '바람 / 강수',
+            humidityShort: '습도',
+            cloudShort: '운량',
+            rainRisk: '강수 확률',
+            shortwave: '단파복사',
+            windMax: '최대 풍속',
+            sunHours: '시간 일조',
+        }
+        : {
+            title: 'Daegu Live Weather',
+            subtitle: 'Current conditions + 3-day outlook for Daegu',
+            loading: 'Loading live Daegu weather...',
+            unavailable: 'Weather panel is unavailable',
+            feelsLike: 'feels like',
+            humidityClouds: 'Humidity / Clouds',
+            windRain: 'Wind / Rain',
+            humidityShort: 'RH',
+            cloudShort: 'Cloud',
+            rainRisk: 'Rain risk',
+            shortwave: 'Shortwave',
+            windMax: 'Wind max',
+            sunHours: 'h sun',
+        };
+    const formatForecastLabel = (date: string): string =>
+        formatLocaleDate(locale, `${date}T00:00:00`, { month: 'short', day: 'numeric', weekday: 'short' });
+    const today = weather?.daily[0];
+    const currentWeatherLabel = weather ? getWeatherLabel(weather.current.weather_code, weather.current.weather_label, locale) : '';
+    const summary = weather
+        ? locale === 'ko'
+            ? `현재 대구는 ${currentWeatherLabel} 상태이며 기온은 ${weather.current.temperature_c.toFixed(1)}°C, 풍속은 ${weather.current.wind_speed_kmh.toFixed(1)} km/h입니다. 오늘은 최고 ${(today?.temperature_max_c ?? weather.current.temperature_c).toFixed(1)}°C / 최저 ${(today?.temperature_min_c ?? weather.current.temperature_c).toFixed(1)}°C, 강수 확률 최대 ${(today?.precipitation_probability_max_pct ?? 0).toFixed(0)}%가 예상됩니다.`
+            : `Daegu is currently ${currentWeatherLabel.toLowerCase()} at ${weather.current.temperature_c.toFixed(1)}°C with ${weather.current.wind_speed_kmh.toFixed(1)} km/h wind. Today reaches ${(today?.temperature_max_c ?? weather.current.temperature_c).toFixed(1)}°C / ${(today?.temperature_min_c ?? weather.current.temperature_c).toFixed(1)}°C with up to ${(today?.precipitation_probability_max_pct ?? 0).toFixed(0)}% rain risk.`
+        : '';
 
-const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelProps) => (
+    return (
     <div className="flex h-full flex-col rounded-xl border border-slate-100 bg-white p-5 shadow-sm">
         <div className="mb-4 flex items-start justify-between gap-3">
             <div>
                 <div className="flex items-center gap-2 text-slate-800">
                     <CloudSun className="h-5 w-5 text-sky-500" />
-                    <h3 className="font-semibold">Daegu Live Weather</h3>
+                    <h3 className="font-semibold">{copy.title}</h3>
                 </div>
-                <p className="mt-1 text-xs text-slate-400">Current conditions + 3-day outlook for Daegu</p>
+                <p className="mt-1 text-xs text-slate-400">{copy.subtitle}</p>
             </div>
             <div className="rounded-full bg-sky-50 px-3 py-1 text-[11px] font-medium text-sky-700">
                 Open-Meteo
@@ -26,10 +69,10 @@ const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelPro
         </div>
 
         {loading ? (
-            <div className="rounded-lg bg-slate-50 p-4 text-sm text-slate-500">Loading live Daegu weather...</div>
+            <div className="rounded-lg bg-slate-50 p-4 text-sm text-slate-500">{copy.loading}</div>
         ) : error ? (
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-                Weather panel is unavailable: {error}
+                {copy.unavailable}: {error}
             </div>
         ) : weather ? (
             <div className="flex h-full flex-col space-y-4">
@@ -38,38 +81,38 @@ const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelPro
                         <div>
                             <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                                 <MapPinned className="h-3.5 w-3.5 text-sky-600" />
-                                <span>{weather.location.name}, {weather.location.country}</span>
+                                <span>{weather.location.name}, {getCountryLabel(weather.location.country, locale)}</span>
                             </div>
                             <div className="mt-2 flex items-baseline gap-2 text-slate-900">
                                 <span className="text-3xl font-bold">{weather.current.temperature_c.toFixed(1)}°C</span>
                                 <span className="text-sm text-slate-500">
-                                    feels like {weather.current.apparent_temperature_c.toFixed(1)}°C
+                                    {copy.feelsLike} {weather.current.apparent_temperature_c.toFixed(1)}°C
                                 </span>
                             </div>
-                            <p className="mt-2 text-sm font-medium text-slate-700">{weather.current.weather_label}</p>
+                            <p className="mt-2 text-sm font-medium text-slate-700">{currentWeatherLabel}</p>
                         </div>
                         <div className="rounded-2xl bg-white/80 px-3 py-2 text-right text-xs text-slate-500 shadow-sm">
-                            <div>{new Date(weather.current.time).toLocaleString()}</div>
+                            <div>{formatLocaleDateTime(locale, weather.current.time)}</div>
                             <div className="mt-1">{weather.location.timezone}</div>
                         </div>
                     </div>
-                    <p className="mt-3 text-sm leading-relaxed text-slate-600">{weather.summary}</p>
+                    <p className="mt-3 text-sm leading-relaxed text-slate-600">{summary}</p>
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
                     <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
                         <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                             <Thermometer className="h-4 w-4 text-orange-500" />
-                            <span>Humidity / Clouds</span>
+                            <span>{copy.humidityClouds}</span>
                         </div>
                         <div className="mt-2 text-sm text-slate-700">
-                            RH {weather.current.relative_humidity_pct.toFixed(0)}% | Cloud {weather.current.cloud_cover_pct.toFixed(0)}%
+                            {copy.humidityShort} {weather.current.relative_humidity_pct.toFixed(0)}% | {copy.cloudShort} {weather.current.cloud_cover_pct.toFixed(0)}%
                         </div>
                     </div>
                     <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
                         <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
                             <Wind className="h-4 w-4 text-teal-500" />
-                            <span>Wind / Rain</span>
+                            <span>{copy.windRain}</span>
                         </div>
                         <div className="mt-2 text-sm text-slate-700">
                             {weather.current.wind_speed_kmh.toFixed(1)} km/h | {weather.current.precipitation_mm.toFixed(1)} mm
@@ -83,27 +126,27 @@ const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelPro
                             <div className="flex items-start justify-between gap-3">
                                 <div>
                                     <div className="text-sm font-semibold text-slate-800">{formatForecastLabel(day.date)}</div>
-                                    <div className="mt-1 text-xs text-slate-500">{day.weather_label}</div>
+                                    <div className="mt-1 text-xs text-slate-500">{getWeatherLabel(day.weather_code, day.weather_label, locale)}</div>
                                 </div>
                                 <div className="text-right text-sm text-slate-700">
                                     <div className="font-semibold">{day.temperature_max_c.toFixed(1)}°C / {day.temperature_min_c.toFixed(1)}°C</div>
-                                    <div className="mt-1 text-xs text-slate-500">{day.sunshine_duration_h.toFixed(1)} h sun</div>
+                                    <div className="mt-1 text-xs text-slate-500">{day.sunshine_duration_h.toFixed(1)} {copy.sunHours}</div>
                                 </div>
                             </div>
                             <div className="mt-3 grid grid-cols-3 gap-2 text-xs text-slate-500">
                                 <div className="rounded-md bg-slate-50 px-2 py-2">
                                     <div className="flex items-center gap-1">
                                         <CloudRain className="h-3.5 w-3.5 text-cyan-500" />
-                                        <span>Rain risk</span>
+                                        <span>{copy.rainRisk}</span>
                                     </div>
                                     <div className="mt-1 font-medium text-slate-700">{day.precipitation_probability_max_pct.toFixed(0)}%</div>
                                 </div>
                                 <div className="rounded-md bg-slate-50 px-2 py-2">
-                                    <div>Shortwave</div>
+                                    <div>{copy.shortwave}</div>
                                     <div className="mt-1 font-medium text-slate-700">{day.shortwave_radiation_sum_mj_m2.toFixed(1)} MJ m⁻²</div>
                                 </div>
                                 <div className="rounded-md bg-slate-50 px-2 py-2">
-                                    <div>Wind max</div>
+                                    <div>{copy.windMax}</div>
                                     <div className="mt-1 font-medium text-slate-700">{day.wind_speed_max_kmh.toFixed(1)} km/h</div>
                                 </div>
                             </div>
@@ -113,6 +156,7 @@ const WeatherOutlookPanel = ({ weather, loading, error }: WeatherOutlookPanelPro
             </div>
         ) : null}
     </div>
-);
+    );
+};
 
 export default WeatherOutlookPanel;

--- a/frontend/src/hooks/useAiAssistant.ts
+++ b/frontend/src/hooks/useAiAssistant.ts
@@ -8,6 +8,7 @@ import type {
     WeatherOutlook,
 } from '../types';
 import { API_URL } from '../config';
+import { useLocale } from '../i18n/LocaleProvider';
 import { buildAiDashboardContext } from '../utils/aiDashboardContext';
 
 type ConsultResponse = {
@@ -17,6 +18,7 @@ type ConsultResponse = {
 };
 
 export const useAiAssistant = () => {
+    const { locale } = useLocale();
     const [aiAnalysis, setAiAnalysis] = useState<string>("");
     const [isAnalyzing, setIsAnalyzing] = useState(false);
 
@@ -45,7 +47,7 @@ export const useAiAssistant = () => {
             const res = await fetch(`${API_URL}/ai/consult`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ crop: cropKey, dashboard, language: 'en' })
+                body: JSON.stringify({ crop: cropKey, dashboard, language: locale })
             });
             const raw = await res.text();
             let json: ConsultResponse | null = null;
@@ -64,12 +66,16 @@ export const useAiAssistant = () => {
             if (callback) callback([]);
         } catch (e) {
             const message =
-                e instanceof Error ? e.message : "An unknown error occurred.";
-            setAiAnalysis(`AI consulting is unavailable: ${message}`);
+                e instanceof Error ? e.message : locale === 'ko' ? '알 수 없는 오류가 발생했습니다.' : 'An unknown error occurred.';
+            setAiAnalysis(
+                locale === 'ko'
+                    ? `AI 컨설팅을 사용할 수 없습니다: ${message}`
+                    : `AI consulting is unavailable: ${message}`,
+            );
         } finally {
             setIsAnalyzing(false);
         }
-    }, []);
+    }, [locale]);
 
     return {
         aiAnalysis,

--- a/frontend/src/hooks/useGreenhouse.ts
+++ b/frontend/src/hooks/useGreenhouse.ts
@@ -9,6 +9,8 @@ import type {
     MetricHistoryPoint,
 } from '../types';
 import { API_URL, WS_URL } from '../config';
+import { useLocale } from '../i18n/LocaleProvider';
+import { formatLocaleDate, formatLocaleDateTime } from '../i18n/locale';
 
 const DEFAULT_TEMP_SETTINGS_BY_CROP: Record<CropType, TemperatureSettings> = {
     Tomato: { heating: 18, cooling: 26 },
@@ -105,6 +107,7 @@ const appendUniquePoint = <T extends { timestamp: number }>(series: T[], point: 
 };
 
 export const useGreenhouse = () => {
+    const { locale } = useLocale();
     const [selectedCrop, setSelectedCrop] = useState<CropType>('Cucumber');
     const settingsByCropRef = useRef<Record<CropType, TemperatureSettings>>({
         Tomato: { ...DEFAULT_TEMP_SETTINGS_BY_CROP.Tomato },
@@ -599,8 +602,8 @@ export const useGreenhouse = () => {
     const growthDay = startTimestamp
         ? Math.max(1, Math.floor((currentTimestamp - startTimestamp) / (1000 * 60 * 60 * 24)) + 1)
         : null;
-    const startDateLabel = startTimestamp ? new Date(startTimestamp).toLocaleDateString() : null;
-    const currentDateLabel = new Date(currentTimestamp).toLocaleString();
+    const startDateLabel = startTimestamp ? formatLocaleDate(locale, startTimestamp) : null;
+    const currentDateLabel = formatLocaleDateTime(locale, currentTimestamp);
 
     const defaultMetrics: AdvancedModelMetrics = {
         cropType: selectedCrop,

--- a/frontend/src/i18n/LocaleProvider.tsx
+++ b/frontend/src/i18n/LocaleProvider.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { LOCALE_STORAGE_KEY, resolveAppLocale } from './locale';
+import type { AppLocale } from './locale';
+
+interface LocaleContextValue {
+    locale: AppLocale;
+    setLocale: (locale: AppLocale) => void;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+function resolveInitialLocale(): AppLocale {
+    if (typeof window === 'undefined') {
+        return 'en';
+    }
+
+    try {
+        const storedLocale = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+        if (storedLocale) {
+            return resolveAppLocale(storedLocale);
+        }
+    } catch {
+        // Ignore storage errors and fall back to browser locale.
+    }
+
+    return resolveAppLocale(window.navigator.language);
+}
+
+export const LocaleProvider = ({ children }: { children: ReactNode }) => {
+    const [locale, setLocale] = useState<AppLocale>(resolveInitialLocale);
+
+    useEffect(() => {
+        try {
+            window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+        } catch {
+            // Ignore storage errors.
+        }
+
+        if (typeof document !== 'undefined') {
+            document.documentElement.lang = locale;
+        }
+    }, [locale]);
+
+    const value = useMemo(
+        () => ({
+            locale,
+            setLocale,
+        }),
+        [locale],
+    );
+
+    return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useLocale(): LocaleContextValue {
+    const context = useContext(LocaleContext);
+    if (!context) {
+        throw new Error('useLocale must be used within LocaleProvider.');
+    }
+
+    return context;
+}

--- a/frontend/src/i18n/locale.ts
+++ b/frontend/src/i18n/locale.ts
@@ -1,0 +1,56 @@
+export type AppLocale = 'en' | 'ko';
+
+export const LOCALE_STORAGE_KEY = 'smartgrow-dashboard-locale';
+
+const INTL_LOCALE_BY_APP_LOCALE: Record<AppLocale, string> = {
+    en: 'en-US',
+    ko: 'ko-KR',
+};
+
+export function resolveAppLocale(value?: string | null): AppLocale {
+    return (value ?? '').toLowerCase().startsWith('ko') ? 'ko' : 'en';
+}
+
+export function getIntlLocale(locale: AppLocale): string {
+    return INTL_LOCALE_BY_APP_LOCALE[locale];
+}
+
+function toDate(value: string | number | Date): Date {
+    return value instanceof Date ? value : new Date(value);
+}
+
+export function formatLocaleDate(
+    locale: AppLocale,
+    value: string | number | Date,
+    options?: Intl.DateTimeFormatOptions,
+): string {
+    const date = toDate(value);
+    if (Number.isNaN(date.getTime())) {
+        return typeof value === 'string' ? value : '';
+    }
+    return date.toLocaleDateString(getIntlLocale(locale), options);
+}
+
+export function formatLocaleTime(
+    locale: AppLocale,
+    value: string | number | Date,
+    options?: Intl.DateTimeFormatOptions,
+): string {
+    const date = toDate(value);
+    if (Number.isNaN(date.getTime())) {
+        return typeof value === 'string' ? value : '';
+    }
+    return date.toLocaleTimeString(getIntlLocale(locale), options);
+}
+
+export function formatLocaleDateTime(
+    locale: AppLocale,
+    value: string | number | Date,
+    options?: Intl.DateTimeFormatOptions,
+): string {
+    const date = toDate(value);
+    if (Number.isNaN(date.getTime())) {
+        return typeof value === 'string' ? value : '';
+    }
+    return date.toLocaleString(getIntlLocale(locale), options);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { LocaleProvider } from './i18n/LocaleProvider.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <LocaleProvider>
+      <App />
+    </LocaleProvider>
   </StrictMode>,
 )

--- a/frontend/src/utils/displayCopy.ts
+++ b/frontend/src/utils/displayCopy.ts
@@ -1,4 +1,5 @@
 import type { CropType } from '../types';
+import type { AppLocale } from '../i18n/locale';
 
 export const UNIT_LABELS = {
     temperature: '°C',
@@ -18,16 +19,26 @@ export const UNIT_LABELS = {
     energyUse: 'kWh',
 } as const;
 
-export const DASHBOARD_SENSOR_COPY = {
-    temperature: { title: 'Air Temperature', unit: UNIT_LABELS.temperature },
-    humidity: { title: 'Relative Humidity', unit: UNIT_LABELS.humidity },
-    carbonDioxide: { title: 'CO₂ Concentration', unit: UNIT_LABELS.carbonDioxide },
-    light: { title: 'Photosynthetic Photon Flux Density', unit: UNIT_LABELS.photonFlux },
-    vpd: { title: 'Vapor Pressure Deficit', unit: UNIT_LABELS.vpd },
-    stomatalConductance: { title: 'Stomatal Conductance', unit: UNIT_LABELS.stomatalConductance },
+const DASHBOARD_SENSOR_TITLES = {
+    en: {
+        temperature: 'Air Temperature',
+        humidity: 'Relative Humidity',
+        carbonDioxide: 'CO₂ Concentration',
+        light: 'Photosynthetic Photon Flux Density',
+        vpd: 'Vapor Pressure Deficit',
+        stomatalConductance: 'Stomatal Conductance',
+    },
+    ko: {
+        temperature: '기온',
+        humidity: '상대습도',
+        carbonDioxide: 'CO₂ 농도',
+        light: '광합성 광양자속 밀도',
+        vpd: '증기압 포차',
+        stomatalConductance: '기공전도도',
+    },
 } as const;
 
-export const IDEAL_RANGES: Record<CropType, Record<'temperature' | 'humidity' | 'light' | 'vpd', string>> = {
+const IDEAL_RANGES: Record<CropType, Record<'temperature' | 'humidity' | 'light' | 'vpd', string>> = {
     Tomato: {
         temperature: '18-26 °C',
         humidity: '60-80 %',
@@ -42,11 +53,144 @@ export const IDEAL_RANGES: Record<CropType, Record<'temperature' | 'humidity' | 
     },
 };
 
-export const getCropModelLabel = (crop: CropType): string =>
-    crop === 'Tomato' ? 'Tomato digital twin' : 'Cucumber digital twin';
+const WEATHER_LABELS_KO: Record<number, string> = {
+    0: '맑음',
+    1: '대체로 맑음',
+    2: '구름 조금',
+    3: '흐림',
+    45: '안개',
+    48: '착빙 안개',
+    51: '약한 이슬비',
+    53: '보통 이슬비',
+    55: '강한 이슬비',
+    56: '약한 어는 이슬비',
+    57: '강한 어는 이슬비',
+    61: '약한 비',
+    63: '보통 비',
+    65: '강한 비',
+    66: '약한 어는 비',
+    67: '강한 어는 비',
+    71: '약한 눈',
+    73: '보통 눈',
+    75: '강한 눈',
+    77: '싸락눈',
+    80: '약한 소나기',
+    81: '보통 소나기',
+    82: '매우 강한 소나기',
+    85: '약한 눈 소나기',
+    86: '강한 눈 소나기',
+    95: '뇌우',
+    96: '약한 우박을 동반한 뇌우',
+    99: '강한 우박을 동반한 뇌우',
+};
 
-export const getCropStatusLabel = (crop: CropType): string =>
-    crop === 'Tomato' ? 'Active trusses' : 'Node count';
+const WEATHER_LABELS_BY_ENGLISH: Record<string, string> = {
+    'Clear sky': '맑음',
+    'Mainly clear': '대체로 맑음',
+    'Partly cloudy': '구름 조금',
+    'Overcast': '흐림',
+    'Fog': '안개',
+    'Rime fog': '착빙 안개',
+    'Light drizzle': '약한 이슬비',
+    'Moderate drizzle': '보통 이슬비',
+    'Dense drizzle': '강한 이슬비',
+    'Light freezing drizzle': '약한 어는 이슬비',
+    'Dense freezing drizzle': '강한 어는 이슬비',
+    'Slight rain': '약한 비',
+    'Moderate rain': '보통 비',
+    'Heavy rain': '강한 비',
+    'Light freezing rain': '약한 어는 비',
+    'Heavy freezing rain': '강한 어는 비',
+    'Slight snow': '약한 눈',
+    'Moderate snow': '보통 눈',
+    'Heavy snow': '강한 눈',
+    'Snow grains': '싸락눈',
+    'Light rain showers': '약한 소나기',
+    'Moderate rain showers': '보통 소나기',
+    'Violent rain showers': '매우 강한 소나기',
+    'Light snow showers': '약한 눈 소나기',
+    'Heavy snow showers': '강한 눈 소나기',
+    'Thunderstorm': '뇌우',
+    'Thunderstorm with slight hail': '약한 우박을 동반한 뇌우',
+    'Thunderstorm with heavy hail': '강한 우박을 동반한 뇌우',
+    'Unknown conditions': '상태 정보 없음',
+};
 
-export const getForecastTitle = (crop: CropType): string =>
-    `7-day harvest and water forecast: ${crop}`;
+const DEVELOPMENT_STAGE_LABELS: Record<string, { en: string; ko: string }> = {
+    Init: { en: 'Init', ko: '초기화' },
+    Growing: { en: 'Growing', ko: '생육 중' },
+    Vegetative: { en: 'Vegetative', ko: '영양생장' },
+    Generative: { en: 'Generative', ko: '생식생장' },
+    Flowering: { en: 'Flowering', ko: '개화기' },
+    Fruiting: { en: 'Fruiting', ko: '결실기' },
+    Harvest: { en: 'Harvest', ko: '수확기' },
+};
+
+const PRODUCE_LABELS: Record<string, { en: string; ko: string }> = {
+    Tomato: { en: 'Tomato', ko: '토마토' },
+    'Cherry Tomato': { en: 'Cherry Tomato', ko: '방울토마토' },
+    'Cucumber (Dadagi)': { en: 'Cucumber (Dadagi)', ko: '오이(다다기)' },
+    'Cucumber (Chuicheong)': { en: 'Cucumber (Chuicheong)', ko: '오이(취청)' },
+};
+
+export function getDashboardSensorCopy(locale: AppLocale) {
+    const titles = DASHBOARD_SENSOR_TITLES[locale];
+    return {
+        temperature: { title: titles.temperature, unit: UNIT_LABELS.temperature },
+        humidity: { title: titles.humidity, unit: UNIT_LABELS.humidity },
+        carbonDioxide: { title: titles.carbonDioxide, unit: UNIT_LABELS.carbonDioxide },
+        light: { title: titles.light, unit: UNIT_LABELS.photonFlux },
+        vpd: { title: titles.vpd, unit: UNIT_LABELS.vpd },
+        stomatalConductance: { title: titles.stomatalConductance, unit: UNIT_LABELS.stomatalConductance },
+    } as const;
+}
+
+export const getIdealRanges = (_locale: AppLocale) => {
+    void _locale;
+    return IDEAL_RANGES;
+};
+
+export const getCropLabel = (crop: CropType, locale: AppLocale): string =>
+    crop === 'Tomato'
+        ? (locale === 'ko' ? '토마토' : 'Tomato')
+        : (locale === 'ko' ? '오이' : 'Cucumber');
+
+export const getCropModelLabel = (crop: CropType, locale: AppLocale): string =>
+    crop === 'Tomato'
+        ? (locale === 'ko' ? '토마토 디지털 트윈' : 'Tomato digital twin')
+        : (locale === 'ko' ? '오이 디지털 트윈' : 'Cucumber digital twin');
+
+export const getCropStatusLabel = (crop: CropType, locale: AppLocale): string =>
+    crop === 'Tomato'
+        ? (locale === 'ko' ? '활성 화방 수' : 'Active trusses')
+        : (locale === 'ko' ? '마디 수' : 'Node count');
+
+export const getForecastTitle = (crop: CropType, locale: AppLocale): string =>
+    locale === 'ko'
+        ? `7일 수확·관수 전망: ${getCropLabel(crop, locale)}`
+        : `7-day harvest and water forecast: ${crop}`;
+
+export const getWeatherLabel = (
+    weatherCode: number | null | undefined,
+    fallbackLabel: string | undefined,
+    locale: AppLocale,
+): string => {
+    if (locale === 'en') {
+        return fallbackLabel || 'Unknown conditions';
+    }
+
+    if (typeof weatherCode === 'number' && weatherCode in WEATHER_LABELS_KO) {
+        return WEATHER_LABELS_KO[weatherCode];
+    }
+
+    return WEATHER_LABELS_BY_ENGLISH[fallbackLabel ?? ''] ?? fallbackLabel ?? '상태 정보 없음';
+};
+
+export const getDevelopmentStageLabel = (stage: string, locale: AppLocale): string =>
+    DEVELOPMENT_STAGE_LABELS[stage]?.[locale] ?? stage;
+
+export const getProduceDisplayName = (name: string, locale: AppLocale): string =>
+    PRODUCE_LABELS[name]?.[locale] ?? name;
+
+export const getCountryLabel = (country: string, locale: AppLocale): string =>
+    country === 'South Korea' && locale === 'ko' ? '대한민국' : country;


### PR DESCRIPTION
## Summary
- add a persisted EN/한국어 locale toggle and browser-locale bootstrapping for the dashboard shell
- localize AI consult/chat requests plus dashboard panels, cards, charts, tooltips, and produce/RTR/weather summaries
- validate Korean rendering with lint/ruff/pytest/build and a browser smoke screenshot

## Validation
- npm --prefix frontend run lint
- poetry run ruff check .
- poetry run pytest
- npm --prefix frontend run build
- browser smoke on http://127.0.0.1:8000 + http://127.0.0.1:4173 with artifacts/browser-smoke/issue14-korean-dashboard.png

Closes #14