### PR TITLE
fix: user-selectable simulation pacing and full-route layout audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ out/
 results/
 runs*/
 logs/
+screenshots/
+*.screenshot.png
+*.screenshot.jpg
+*.screenshot.jpeg
 .playwright-mcp/
 .rah/
 Phytoritas.md

--- a/frontend/src/components/dashboard/SimulationRuntimePanel.test.tsx
+++ b/frontend/src/components/dashboard/SimulationRuntimePanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SimulationRuntimePanel from './SimulationRuntimePanel';
 
@@ -12,6 +12,15 @@ function renderPanel() {
       telemetryStatus="live"
     />,
   );
+}
+
+function mockSpeedResponse(ok: boolean) {
+  fetchMock.mockResolvedValue({
+    ok,
+    status: ok ? 200 : 422,
+    statusText: ok ? 'OK' : 'Unprocessable Entity',
+    json: async () => (ok ? { status: 'success' } : { detail: 'invalid pace' }),
+  });
 }
 
 describe('SimulationRuntimePanel', () => {
@@ -39,8 +48,9 @@ describe('SimulationRuntimePanel', () => {
     expect(screen.getByRole('button', { name: '600 s/s' }).getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('restores and persists sg-sim-pace from localStorage', () => {
+  it('posts the pace and persists sg-sim-pace when /api/speed succeeds', async () => {
     window.localStorage.setItem('sg-sim-pace', '60');
+    mockSpeedResponse(true);
 
     renderPanel();
 
@@ -48,7 +58,32 @@ describe('SimulationRuntimePanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '6000 s/s' }));
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '6000 s/s' }).getAttribute('aria-pressed')).toBe('true');
+    });
+
+    const speedCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/speed'));
+    expect(speedCall).toBeTruthy();
+    const body = JSON.parse((speedCall?.[1]?.body as string) ?? '{}');
+    expect(body.sim_seconds_per_real_second).toBe(6000);
     expect(window.localStorage.getItem('sg-sim-pace')).toBe('6000');
-    expect(screen.getByRole('button', { name: '6000 s/s' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('keeps the active preset and does not persist when /api/speed fails', async () => {
+    window.localStorage.setItem('sg-sim-pace', '60');
+    mockSpeedResponse(false);
+
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: '6000 s/s' }));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/speed'))).toBe(true);
+    });
+
+    // R10: a rejected pace must not move the active indicator or the stored value.
+    expect(screen.getByRole('button', { name: '60 s/s' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: '6000 s/s' }).getAttribute('aria-pressed')).toBe('false');
+    expect(window.localStorage.getItem('sg-sim-pace')).toBe('60');
   });
 });

--- a/frontend/src/components/dashboard/SimulationRuntimePanel.test.tsx
+++ b/frontend/src/components/dashboard/SimulationRuntimePanel.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SimulationRuntimePanel from './SimulationRuntimePanel';
+
+const fetchMock = vi.fn();
+
+function renderPanel() {
+  return render(
+    <SimulationRuntimePanel
+      locale="en"
+      crop="Cucumber"
+      telemetryStatus="live"
+    />,
+  );
+}
+
+describe('SimulationRuntimePanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders discrete simulation pace presets without a numeric spinbutton', () => {
+    renderPanel();
+
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    expect(screen.getByRole('group', { name: 'Speed' })).toBeTruthy();
+
+    for (const label of ['10 s/s', '20 s/s', '30 s/s', '60 s/s', '600 s/s', '6000 s/s']) {
+      expect(screen.getByRole('button', { name: label })).toBeTruthy();
+    }
+
+    expect(screen.getByRole('button', { name: '600 s/s' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('restores and persists sg-sim-pace from localStorage', () => {
+    window.localStorage.setItem('sg-sim-pace', '60');
+
+    renderPanel();
+
+    expect(screen.getByRole('button', { name: '60 s/s' }).getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: '6000 s/s' }));
+
+    expect(window.localStorage.getItem('sg-sim-pace')).toBe('6000');
+    expect(screen.getByRole('button', { name: '6000 s/s' }).getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
+++ b/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
@@ -3,13 +3,16 @@ import { Activity, Gauge, Loader2, Pause, Play, RotateCcw, SkipForward, Square, 
 import type { AppLocale } from '../../i18n/locale';
 import type { CropType, TelemetryStatus } from '../../types';
 import {
+  simulationRuntimePacePresets,
   simulationRuntimeTimeSteps,
   type SimulationRuntimeAction,
+  type SimulationRuntimePacePreset,
   type SimulationRuntimeTimeStep,
   useSimulationRuntimeControls,
 } from '../../hooks/useSimulationRuntimeControls';
 import { Button } from '../ui/button';
 import { StatusChip } from '../ui/status-chip';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 
 interface SimulationRuntimePanelProps {
   locale: AppLocale;
@@ -19,6 +22,8 @@ interface SimulationRuntimePanelProps {
 }
 
 const ACTION_ORDER: SimulationRuntimeAction[] = ['start', 'step', 'run', 'pause', 'resume', 'stop', 'speed'];
+const DEFAULT_SIMULATION_PACE: SimulationRuntimePacePreset = 600;
+const PACE_STORAGE_KEY = 'sg-sim-pace';
 
 function statusTone(status: TelemetryStatus): 'growth' | 'stable' | 'warning' | 'critical' {
   if (status === 'live') return 'growth';
@@ -34,6 +39,35 @@ function requestTone(status: 'idle' | 'loading' | 'success' | 'error'): 'growth'
   return 'muted';
 }
 
+function isPacePreset(value: number): value is SimulationRuntimePacePreset {
+  return simulationRuntimePacePresets.some((preset) => preset === value);
+}
+
+function readStoredPace(): SimulationRuntimePacePreset {
+  if (typeof window === 'undefined') {
+    return DEFAULT_SIMULATION_PACE;
+  }
+
+  try {
+    const storedPace = Number(window.localStorage.getItem(PACE_STORAGE_KEY));
+    return isPacePreset(storedPace) ? storedPace : DEFAULT_SIMULATION_PACE;
+  } catch {
+    return DEFAULT_SIMULATION_PACE;
+  }
+}
+
+function persistPace(value: SimulationRuntimePacePreset): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(PACE_STORAGE_KEY, String(value));
+  } catch {
+    // Keep runtime controls usable when storage is unavailable.
+  }
+}
+
 export default function SimulationRuntimePanel({
   locale,
   crop,
@@ -41,7 +75,7 @@ export default function SimulationRuntimePanel({
   telemetryDetail = null,
 }: SimulationRuntimePanelProps) {
   const [timeStep, setTimeStep] = useState<SimulationRuntimeTimeStep>('auto');
-  const [speed, setSpeedValue] = useState(1);
+  const [pace, setPace] = useState<SimulationRuntimePacePreset>(() => readStoredPace());
   const runtime = useSimulationRuntimeControls(crop);
   const isBusy = ACTION_ORDER.some((action) => runtime.state[action].status === 'loading');
   const latestAction = useMemo(() => (
@@ -92,6 +126,11 @@ export default function SimulationRuntimePanel({
 
   const latestState = runtime.state[latestAction];
 
+  const handlePaceSelect = (nextPace: SimulationRuntimePacePreset) => {
+    setPace(nextPace);
+    persistPace(nextPace);
+  };
+
   return (
     <section className="sg-panel p-4" aria-labelledby="simulation-runtime-title">
       <div className="flex flex-col gap-3 border-b border-[color:var(--sg-outline-soft)] pb-3 lg:flex-row lg:items-end lg:justify-between">
@@ -138,19 +177,28 @@ export default function SimulationRuntimePanel({
             </select>
           </div>
           <div>
-            <label htmlFor="runtime-speed" className="text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--sg-text-faint)]">
+            <span id="runtime-speed-label" className="text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--sg-text-faint)]">
               {copy.speed}
-            </label>
-            <input
-              id="runtime-speed"
-              type="number"
-              min="0.1"
-              max="100"
-              step="0.1"
-              value={speed}
-              onChange={(event) => setSpeedValue(Number(event.target.value))}
-              className="sg-data-number mt-2 h-10 w-full rounded-[var(--sg-radius-sm)] border border-[color:var(--sg-outline-soft)] bg-white px-3 text-sm font-semibold text-[color:var(--sg-text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
-            />
+            </span>
+            <ToggleGroup
+              role="group"
+              aria-labelledby="runtime-speed-label"
+              className="mt-2 grid w-full grid-cols-3 gap-1 rounded-[var(--sg-radius-sm)] bg-white p-1 shadow-none"
+            >
+              {simulationRuntimePacePresets.map((preset) => (
+                <ToggleGroupItem
+                  key={preset}
+                  pressed={pace === preset}
+                  aria-label={`${preset} s/s`}
+                  aria-pressed={pace === preset}
+                  onClick={() => handlePaceSelect(preset)}
+                  className="inline-flex h-10 min-w-0 items-baseline justify-center gap-1 rounded-[var(--sg-radius-sm)] px-2 py-2"
+                >
+                  <span className="sg-data-number text-sm font-bold">{preset}</span>
+                  <span className="text-[10px] font-bold uppercase opacity-70">s/s</span>
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
           </div>
         </div>
 
@@ -167,7 +215,7 @@ export default function SimulationRuntimePanel({
             <RotateCcw className="h-4 w-4" aria-hidden="true" />
             {copy.run}
           </Button>
-          <Button variant="secondary" disabled={isBusy || !Number.isFinite(speed) || speed <= 0} onClick={() => { void runtime.setSpeed(speed); }}>
+          <Button variant="secondary" disabled={isBusy} onClick={() => { void runtime.setSpeed(pace); }}>
             <Gauge className="h-4 w-4" aria-hidden="true" />
             {copy.applySpeed}
           </Button>

--- a/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
+++ b/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
@@ -3,8 +3,11 @@ import { Activity, Gauge, Loader2, Pause, Play, RotateCcw, SkipForward, Square, 
 import type { AppLocale } from '../../i18n/locale';
 import type { CropType, TelemetryStatus } from '../../types';
 import {
+  DEFAULT_SIMULATION_PACE,
+  readStoredSimulationPace,
   simulationRuntimePacePresets,
   simulationRuntimeTimeSteps,
+  writeStoredSimulationPace,
   type SimulationRuntimeAction,
   type SimulationRuntimePacePreset,
   type SimulationRuntimeTimeStep,
@@ -22,8 +25,6 @@ interface SimulationRuntimePanelProps {
 }
 
 const ACTION_ORDER: SimulationRuntimeAction[] = ['start', 'step', 'run', 'pause', 'resume', 'stop', 'speed'];
-const DEFAULT_SIMULATION_PACE: SimulationRuntimePacePreset = 600;
-const PACE_STORAGE_KEY = 'sg-sim-pace';
 
 function statusTone(status: TelemetryStatus): 'growth' | 'stable' | 'warning' | 'critical' {
   if (status === 'live') return 'growth';
@@ -39,35 +40,6 @@ function requestTone(status: 'idle' | 'loading' | 'success' | 'error'): 'growth'
   return 'muted';
 }
 
-function isPacePreset(value: number): value is SimulationRuntimePacePreset {
-  return simulationRuntimePacePresets.some((preset) => preset === value);
-}
-
-function readStoredPace(): SimulationRuntimePacePreset {
-  if (typeof window === 'undefined') {
-    return DEFAULT_SIMULATION_PACE;
-  }
-
-  try {
-    const storedPace = Number(window.localStorage.getItem(PACE_STORAGE_KEY));
-    return isPacePreset(storedPace) ? storedPace : DEFAULT_SIMULATION_PACE;
-  } catch {
-    return DEFAULT_SIMULATION_PACE;
-  }
-}
-
-function persistPace(value: SimulationRuntimePacePreset): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(PACE_STORAGE_KEY, String(value));
-  } catch {
-    // Keep runtime controls usable when storage is unavailable.
-  }
-}
-
 export default function SimulationRuntimePanel({
   locale,
   crop,
@@ -75,7 +47,9 @@ export default function SimulationRuntimePanel({
   telemetryDetail = null,
 }: SimulationRuntimePanelProps) {
   const [timeStep, setTimeStep] = useState<SimulationRuntimeTimeStep>('auto');
-  const [pace, setPace] = useState<SimulationRuntimePacePreset>(() => readStoredPace());
+  const [pace, setPace] = useState<SimulationRuntimePacePreset>(
+    () => readStoredSimulationPace() ?? DEFAULT_SIMULATION_PACE,
+  );
   const runtime = useSimulationRuntimeControls(crop);
   const isBusy = ACTION_ORDER.some((action) => runtime.state[action].status === 'loading');
   const latestAction = useMemo(() => (
@@ -126,9 +100,16 @@ export default function SimulationRuntimePanel({
 
   const latestState = runtime.state[latestAction];
 
-  const handlePaceSelect = (nextPace: SimulationRuntimePacePreset) => {
+  const handlePaceSelect = async (nextPace: SimulationRuntimePacePreset) => {
+    const result = await runtime.setSpeed(nextPace);
+    if (result === null) {
+      // R10: the /api/speed request failed. Keep the previously active preset and
+      // let the runtime error state surface below instead of showing a pace that
+      // the backend never accepted.
+      return;
+    }
     setPace(nextPace);
-    persistPace(nextPace);
+    writeStoredSimulationPace(nextPace);
   };
 
   return (
@@ -191,7 +172,8 @@ export default function SimulationRuntimePanel({
                   pressed={pace === preset}
                   aria-label={`${preset} s/s`}
                   aria-pressed={pace === preset}
-                  onClick={() => handlePaceSelect(preset)}
+                  disabled={runtime.state.speed.status === 'loading'}
+                  onClick={() => { void handlePaceSelect(preset); }}
                   className="inline-flex h-10 min-w-0 items-baseline justify-center gap-1 rounded-[var(--sg-radius-sm)] px-2 py-2"
                 >
                   <span className="sg-data-number text-sm font-bold">{preset}</span>

--- a/frontend/src/hooks/useGreenhouse.test.tsx
+++ b/frontend/src/hooks/useGreenhouse.test.tsx
@@ -362,4 +362,44 @@ describe('useGreenhouse', () => {
 
         unmount();
     });
+
+    it('applies the default 600 pace on a fresh connect when nothing is stored (R28)', async () => {
+        // Negative test for R28: with an empty sg-sim-pace the readable default of 600
+        // sim-seconds/real-second must actually be POSTed on the telemetry socket open.
+        // Without this, the backend keeps its legacy step_sim_duration/0.1 fallback
+        // (6000 for the default 10-min data) and the simulation runs away at ~100 sim
+        // minutes per real second while the control still highlights 600.
+        expect(window.localStorage.getItem('sg-sim-pace')).toBeNull();
+
+        const { unmount } = renderHook(() => useGreenhouse());
+
+        await waitFor(() => {
+            expect(findSocket('/ws/sim/cucumber')).toBeDefined();
+        });
+
+        const simSocket = findSocket('/ws/sim/cucumber')!;
+
+        fetchMock.mockClear();
+        await act(async () => {
+            simSocket.readyState = MockWebSocket.OPEN;
+            simSocket.onopen?.(new Event('open'));
+            await Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('/speed'),
+                expect.objectContaining({
+                    method: 'POST',
+                    body: expect.stringContaining('"sim_seconds_per_real_second":600,'),
+                }),
+            );
+        });
+
+        // 600 is the default, not a persisted user choice, so storage stays empty and a
+        // later change to the default constant would still take effect (R28 precedence).
+        expect(window.localStorage.getItem('sg-sim-pace')).toBeNull();
+
+        unmount();
+    });
 });

--- a/frontend/src/hooks/useGreenhouse.test.tsx
+++ b/frontend/src/hooks/useGreenhouse.test.tsx
@@ -86,6 +86,7 @@ describe('useGreenhouse', () => {
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        window.localStorage.clear();
     });
 
     it('does not force a reconnect while the initial socket is still connecting', async () => {
@@ -238,6 +239,126 @@ describe('useGreenhouse', () => {
         });
 
         expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/forecast/cucumber'));
+
+        unmount();
+    });
+
+    it('does not auto-restart the simulation when the backend reports it paused (R13)', async () => {
+        // Negative test for R13: while a crop is paused, the auto-recovery loop in
+        // ensureSimulationRunning must never POST /start, so a user-initiated pause is
+        // not silently overridden by the frontend recovery logic.
+        fetchMock.mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/status')) {
+                return Promise.resolve(jsonResponse({
+                    greenhouses: {
+                        cucumber: {
+                            status: 'paused',
+                            total_rows: 12,
+                            idx: 3,
+                        },
+                    },
+                }));
+            }
+            if (url.includes('/start')) {
+                return Promise.resolve(jsonResponse({ status: 'success' }));
+            }
+            if (url.includes('/settings?crop=')) {
+                return Promise.resolve(jsonResponse({ cost_per_kwh: 0.15 }));
+            }
+            if (url.includes('/forecast/')) {
+                return Promise.resolve(jsonResponse({ daily: [] }));
+            }
+            return Promise.resolve(jsonResponse({}));
+        });
+
+        // The module-level fetch spy accumulates calls across tests; clear it so the
+        // negative /start assertion only sees calls made by this paused-crop scenario.
+        fetchMock.mockClear();
+
+        const { unmount } = renderHook(() => useGreenhouse());
+
+        // Wait until the recovery loop has actually queried /status for the crop.
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('/status'),
+                expect.anything(),
+            );
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(fetchMock).not.toHaveBeenCalledWith(
+            expect.stringContaining('/start'),
+            expect.objectContaining({ method: 'POST' }),
+        );
+
+        unmount();
+    });
+
+    it('preserves chart history and crop selection when a pace change is reapplied on connect (R14)', async () => {
+        // Negative test for R14: a pace change (persisted to sg-sim-pace and reapplied via
+        // applyStoredSimulationPace on the telemetry socket open, per R11) must not reset the
+        // accumulated chart history arrays or the current crop selection.
+        window.localStorage.setItem('sg-sim-pace', '30');
+
+        const { result, unmount } = renderHook(() => useGreenhouse());
+
+        await waitFor(() => {
+            expect(findSocket('/ws/sim/cucumber')).toBeDefined();
+        });
+
+        const simSocket = findSocket('/ws/sim/cucumber')!;
+
+        // Accumulate one chart-history point from a telemetry frame.
+        await act(async () => {
+            simSocket.onmessage?.({
+                data: JSON.stringify({
+                    t: '2026-04-26T00:00:00Z',
+                    env: {
+                        T_air_C: 23,
+                        RH_percent: 70,
+                        CO2_ppm: 550,
+                        PAR_umol: 410,
+                        VPD_kPa: 0.9,
+                    },
+                    state: { LAI: 2.1 },
+                    kpi: {},
+                }),
+            } as MessageEvent<string>);
+        });
+
+        await waitFor(() => {
+            expect(result.current.history.length).toBeGreaterThan(0);
+        });
+
+        const historyLengthBeforePace = result.current.history.length;
+        const cropBeforePace = result.current.selectedCrop;
+
+        // User changes the pace: the panel persists the new preset, then a (re)connect
+        // reapplies it against the backend via POST /speed.
+        window.localStorage.setItem('sg-sim-pace', '6000');
+        fetchMock.mockClear();
+        await act(async () => {
+            simSocket.readyState = MockWebSocket.OPEN;
+            simSocket.onopen?.(new Event('open'));
+            await Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('/speed'),
+                expect.objectContaining({
+                    method: 'POST',
+                    body: expect.stringContaining('"sim_seconds_per_real_second":6000'),
+                }),
+            );
+        });
+
+        expect(result.current.history.length).toBe(historyLengthBeforePace);
+        expect(result.current.selectedCrop).toBe(cropBeforePace);
 
         unmount();
     });

--- a/frontend/src/hooks/useGreenhouse.ts
+++ b/frontend/src/hooks/useGreenhouse.ts
@@ -12,7 +12,11 @@ import type {
     MetricHistoryPoint,
 } from '../types';
 import { API_URL, FORECAST_WS_URL, WS_URL } from '../config';
-import { buildSimulationPaceRequest, readStoredSimulationPace } from './useSimulationRuntimeControls';
+import {
+    buildSimulationPaceRequest,
+    DEFAULT_SIMULATION_PACE,
+    readStoredSimulationPace,
+} from './useSimulationRuntimeControls';
 import { useAreaUnit } from '../context/AreaUnitContext';
 import { useLocale } from '../i18n/LocaleProvider';
 import { formatLocaleDate, formatLocaleDateTime } from '../i18n/locale';
@@ -368,17 +372,15 @@ export const useGreenhouse = () => {
         setWsConnectionNonce((prev) => prev + 1);
     }, [selectedCrop]);
 
-    // Reapply the user's persisted simulation pace after a (re)connection so a fresh
-    // start or a WebSocket reconnect keeps the selected pace instead of snapping back
-    // to the backend default (R11). Skipped when no pace is stored so the backend's
-    // own default stands.
+    // Reapply the effective simulation pace after a (re)connection so a fresh start or
+    // a WebSocket reconnect keeps the selected pace instead of snapping back to the
+    // backend default (R11). A stored pace wins; otherwise the readable default of 600
+    // sim-seconds/real-second is applied so a fresh load does not run at the legacy
+    // pace (R28), which the backend would otherwise derive as step_sim_duration / 0.1.
     const applyStoredSimulationPace = useCallback(async (cropType: CropType) => {
-        const storedPace = readStoredSimulationPace();
-        if (storedPace === null) {
-            return;
-        }
+        const paceToApply = readStoredSimulationPace() ?? DEFAULT_SIMULATION_PACE;
 
-        const { path, init } = buildSimulationPaceRequest(cropType, storedPace);
+        const { path, init } = buildSimulationPaceRequest(cropType, paceToApply);
         try {
             await fetchWithTimeout(`${API_URL}${path}`, init, PACE_REQUEST_TIMEOUT_MS);
         } catch (err) {

--- a/frontend/src/hooks/useGreenhouse.ts
+++ b/frontend/src/hooks/useGreenhouse.ts
@@ -12,6 +12,7 @@ import type {
     MetricHistoryPoint,
 } from '../types';
 import { API_URL, FORECAST_WS_URL, WS_URL } from '../config';
+import { buildSimulationPaceRequest, readStoredSimulationPace } from './useSimulationRuntimeControls';
 import { useAreaUnit } from '../context/AreaUnitContext';
 import { useLocale } from '../i18n/LocaleProvider';
 import { formatLocaleDate, formatLocaleDateTime } from '../i18n/locale';
@@ -111,6 +112,7 @@ const TELEMETRY_HEALTH_POLL_MS = 2_000;
 const SIMULATION_RECOVERY_BACKOFF_MS = 15_000;
 const STATUS_REQUEST_TIMEOUT_MS = 4_000;
 const START_REQUEST_TIMEOUT_MS = 8_000;
+const PACE_REQUEST_TIMEOUT_MS = 4_000;
 
 const DEFAULT_SENSOR_FIELD_AVAILABILITY: SensorFieldAvailability = {
     temperature: false,
@@ -365,6 +367,29 @@ export const useGreenhouse = () => {
         }));
         setWsConnectionNonce((prev) => prev + 1);
     }, [selectedCrop]);
+
+    // Reapply the user's persisted simulation pace after a (re)connection so a fresh
+    // start or a WebSocket reconnect keeps the selected pace instead of snapping back
+    // to the backend default (R11). Skipped when no pace is stored so the backend's
+    // own default stands.
+    const applyStoredSimulationPace = useCallback(async (cropType: CropType) => {
+        const storedPace = readStoredSimulationPace();
+        if (storedPace === null) {
+            return;
+        }
+
+        const { path, init } = buildSimulationPaceRequest(cropType, storedPace);
+        try {
+            await fetchWithTimeout(`${API_URL}${path}`, init, PACE_REQUEST_TIMEOUT_MS);
+        } catch (err) {
+            const errorName = err instanceof Error ? err.name : '';
+            if (errorName === 'AbortError') {
+                console.warn(`Simulation pace restore for ${cropType} was aborted:`, err);
+                return;
+            }
+            console.warn(`Failed to restore stored simulation pace for ${cropType}:`, err);
+        }
+    }, []);
 
     const ensureSimulationRunning = useCallback(async (cropType: CropType) => {
         if (recoveryRequestInFlightRef.current[cropType]) {
@@ -748,6 +773,7 @@ export const useGreenhouse = () => {
                     status: 'loading',
                 },
             }));
+            void applyStoredSimulationPace(cropAtConnection);
         };
 
         ws.onmessage = (event) => {
@@ -853,7 +879,7 @@ export const useGreenhouse = () => {
                 wsRef.current = null;
             }
         };
-    }, [flushCropState, mapPayloadToData, selectedCrop, wsConnectionNonce]);
+    }, [applyStoredSimulationPace, flushCropState, mapPayloadToData, selectedCrop, wsConnectionNonce]);
 
     useEffect(() => {
         const cropAtConnection = selectedCrop;

--- a/frontend/src/hooks/useSimulationRuntimeControls.ts
+++ b/frontend/src/hooks/useSimulationRuntimeControls.ts
@@ -29,6 +29,10 @@ export type SimulationRuntimePacePreset = typeof PACE_PRESETS[number];
 
 export const simulationRuntimePacePresets = [...PACE_PRESETS];
 
+// Initial default pace: 1 real second maps to 600 simulated seconds (R28).
+export const DEFAULT_SIMULATION_PACE: SimulationRuntimePacePreset = 600;
+export const SIMULATION_PACE_STORAGE_KEY = 'sg-sim-pace';
+
 const LEGACY_DEFAULT_STEP_SIM_SECONDS = 600;
 const LEGACY_REAL_SECONDS_PER_STEP = 0.1;
 
@@ -40,8 +44,68 @@ export function deriveLegacySpeedFromPace(simSecondsPerRealSecond: number): numb
   );
 }
 
+export function isSimulationPacePreset(value: number): value is SimulationRuntimePacePreset {
+  return simulationRuntimePacePresets.some((preset) => preset === value);
+}
+
+/**
+ * Read the persisted pace (R11/R28). Returns null when no valid value is stored so
+ * callers can fall back to the backend's own default without forcing a request.
+ */
+export function readStoredSimulationPace(): SimulationRuntimePacePreset | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SIMULATION_PACE_STORAGE_KEY);
+    if (raw === null) {
+      return null;
+    }
+    const value = Number(raw);
+    return isSimulationPacePreset(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredSimulationPace(pace: SimulationRuntimePacePreset): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(SIMULATION_PACE_STORAGE_KEY, String(pace));
+  } catch {
+    // Keep runtime controls usable when storage is unavailable.
+  }
+}
+
 function cropToApiKey(crop: CropType): Lowercase<CropType> {
   return crop.toLowerCase() as Lowercase<CropType>;
+}
+
+/**
+ * Build the /api/speed request for a pace (R3/R11). Sends the new
+ * sim_seconds_per_real_second field plus a backward-compatible legacy speed
+ * multiplier so callers that reconnect can reapply the stored pace directly.
+ */
+export function buildSimulationPaceRequest(
+  crop: CropType,
+  simSecondsPerRealSecond: number,
+): { path: string; init: RequestInit } {
+  const cropKey = cropToApiKey(crop);
+  return {
+    path: `/speed?crop=${encodeURIComponent(cropKey)}`,
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sim_seconds_per_real_second: simSecondsPerRealSecond,
+        speed: deriveLegacySpeedFromPace(simSecondsPerRealSecond),
+      }),
+    },
+  };
 }
 
 export function getDefaultSimulationCsv(crop: CropType): string {
@@ -169,12 +233,10 @@ export function useSimulationRuntimeControls(crop: CropType) {
   const pause = useCallback(() => execute('pause', `/pause?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
   const resume = useCallback(() => execute('resume', `/resume?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
   const stop = useCallback(() => execute('stop', `/stop?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
-  const setSpeed = useCallback((simSecondsPerRealSecond: number) => execute('speed', `/speed?crop=${encodeURIComponent(cropKey)}`, {
-    body: JSON.stringify({
-      sim_seconds_per_real_second: simSecondsPerRealSecond,
-      speed: deriveLegacySpeedFromPace(simSecondsPerRealSecond),
-    }),
-  }), [cropKey, execute]);
+  const setSpeed = useCallback((simSecondsPerRealSecond: number) => {
+    const { path, init } = buildSimulationPaceRequest(crop, simSecondsPerRealSecond);
+    return execute('speed', path, init);
+  }, [crop, execute]);
 
   return {
     state,

--- a/frontend/src/hooks/useSimulationRuntimeControls.ts
+++ b/frontend/src/hooks/useSimulationRuntimeControls.ts
@@ -24,6 +24,22 @@ export type SimulationRuntimeTimeStep = typeof TIME_STEP_OPTIONS[number];
 
 export const simulationRuntimeTimeSteps = [...TIME_STEP_OPTIONS];
 
+const PACE_PRESETS = [10, 20, 30, 60, 600, 6000] as const;
+export type SimulationRuntimePacePreset = typeof PACE_PRESETS[number];
+
+export const simulationRuntimePacePresets = [...PACE_PRESETS];
+
+const LEGACY_DEFAULT_STEP_SIM_SECONDS = 600;
+const LEGACY_REAL_SECONDS_PER_STEP = 0.1;
+
+export function deriveLegacySpeedFromPace(simSecondsPerRealSecond: number): number {
+  return (
+    Number(simSecondsPerRealSecond)
+    * LEGACY_REAL_SECONDS_PER_STEP
+    / LEGACY_DEFAULT_STEP_SIM_SECONDS
+  );
+}
+
 function cropToApiKey(crop: CropType): Lowercase<CropType> {
   return crop.toLowerCase() as Lowercase<CropType>;
 }
@@ -153,8 +169,11 @@ export function useSimulationRuntimeControls(crop: CropType) {
   const pause = useCallback(() => execute('pause', `/pause?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
   const resume = useCallback(() => execute('resume', `/resume?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
   const stop = useCallback(() => execute('stop', `/stop?crop=${encodeURIComponent(cropKey)}`), [cropKey, execute]);
-  const setSpeed = useCallback((speed: number) => execute('speed', `/speed?crop=${encodeURIComponent(cropKey)}`, {
-    body: JSON.stringify({ speed }),
+  const setSpeed = useCallback((simSecondsPerRealSecond: number) => execute('speed', `/speed?crop=${encodeURIComponent(cropKey)}`, {
+    body: JSON.stringify({
+      sim_seconds_per_real_second: simSecondsPerRealSecond,
+      speed: deriveLegacySpeedFromPace(simSecondsPerRealSecond),
+    }),
   }), [cropKey, execute]);
 
   return {

--- a/src/model_informed_greenhouse_dashboard/backend/app/main.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/main.py
@@ -1,7 +1,9 @@
 """Main FastAPI application entry point."""
 
+import asyncio
 import copy
 import logging
+import math
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -9,7 +11,7 @@ from zoneinfo import ZoneInfo
 import httpx
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Dict, Any, Optional, Literal
 
 from .config import settings, greenhouse_config
@@ -55,6 +57,11 @@ from .services.rtr_profiles import (
     upsert_rtr_good_windows,
 )
 from .services.weather import fetch_daegu_weather_outlook
+from .services.simulator import (
+    LEGACY_REAL_SECONDS_PER_STEP,
+    MAX_SIM_SECONDS_PER_REAL_SECOND,
+    MIN_SIM_SECONDS_PER_REAL_SECOND,
+)
 from .schemas import OpsConfig, CropConfig
 
 class Settings(BaseModel):
@@ -348,6 +355,9 @@ app_state = {
         "sim_task": None,
         "dt_hours": None,
         "time_step": "auto",
+        "step_sim_duration_seconds": None,
+        "sim_seconds_per_real_second": None,
+        "pace_changed_event": None,
         "decision": None,
         "last_irrigation": None,
         "last_energy": None,
@@ -373,6 +383,9 @@ app_state = {
         "sim_task": None,
         "dt_hours": None,
         "time_step": "auto",
+        "step_sim_duration_seconds": None,
+        "sim_seconds_per_real_second": None,
+        "pace_changed_event": None,
         "decision": None,
         "last_irrigation": None,
         "last_energy": None,
@@ -397,6 +410,14 @@ STEP_FREQUENCIES: Dict[str, Optional[str]] = {
     "10min": "10min",
     "1h": "1H",
 }
+STEP_SIM_DURATION_SECONDS: Dict[str, float] = {
+    "1s": 1.0,
+    "1min": 60.0,
+    "10min": 600.0,
+    "1h": 3600.0,
+}
+DEFAULT_STEP_SIM_DURATION_SECONDS = 3600.0
+MAX_SIMULATION_SLEEP_CHUNK_SECONDS = 0.5
 
 CROPS = ("tomato", "cucumber")
 MODEL_RUNTIME_SNAPSHOT_INTERVAL = timedelta(hours=1)
@@ -450,6 +471,82 @@ def _target_crops(crop: Optional[str] = None) -> list[str]:
         return list(CROPS)
 
     return [_validate_crop(crop)]
+
+
+def _clamp_sim_seconds_per_real_second(value: float) -> float:
+    return max(
+        MIN_SIM_SECONDS_PER_REAL_SECOND,
+        min(MAX_SIM_SECONDS_PER_REAL_SECOND, float(value)),
+    )
+
+
+def _default_sim_seconds_per_real_second(step_sim_duration_seconds: float) -> float:
+    return _clamp_sim_seconds_per_real_second(
+        step_sim_duration_seconds / LEGACY_REAL_SECONDS_PER_STEP
+    )
+
+
+def _median_environment_interval_seconds(df_env) -> float:
+    if df_env is None or len(df_env) < 2 or "datetime" not in df_env:
+        return DEFAULT_STEP_SIM_DURATION_SECONDS
+
+    import pandas as pd
+
+    datetimes = pd.to_datetime(df_env["datetime"]).sort_values()
+    intervals_seconds = datetimes.diff().dt.total_seconds().dropna()
+    intervals_seconds = intervals_seconds[intervals_seconds > 0]
+    if intervals_seconds.empty:
+        return DEFAULT_STEP_SIM_DURATION_SECONDS
+
+    return max(1.0, float(intervals_seconds.median()))
+
+
+def _derive_step_sim_duration_seconds(time_step: str, df_env) -> float:
+    if time_step == "auto":
+        return _median_environment_interval_seconds(df_env)
+
+    try:
+        return STEP_SIM_DURATION_SECONDS[time_step]
+    except KeyError:
+        raise HTTPException(status_code=400, detail=f"Unsupported time_step: {time_step}")
+
+
+def _simulation_step_delay_seconds(simulator) -> float:
+    step_sim_duration_seconds = float(
+        getattr(
+            simulator,
+            "step_sim_duration_seconds",
+            max(getattr(simulator, "dt_hours", 1.0), 1e-9) * 3600.0,
+        )
+    )
+    sim_seconds_per_real_second = float(
+        getattr(
+            simulator,
+            "sim_seconds_per_real_second",
+            _default_sim_seconds_per_real_second(step_sim_duration_seconds),
+        )
+    )
+    return step_sim_duration_seconds / max(sim_seconds_per_real_second, 1e-9)
+
+
+async def _sleep_simulation_delay(crop: str, simulator, delay: float) -> None:
+    remaining = max(0.0, float(delay))
+    while remaining > 0 and simulator.running:
+        sleep_for = min(remaining, MAX_SIMULATION_SLEEP_CHUNK_SECONDS)
+        pace_changed_event = app_state[crop].get("pace_changed_event")
+        if pace_changed_event is None:
+            await asyncio.sleep(sleep_for)
+            remaining -= sleep_for
+            continue
+
+        try:
+            await asyncio.wait_for(pace_changed_event.wait(), timeout=sleep_for)
+        except TimeoutError:
+            remaining -= sleep_for
+            continue
+
+        pace_changed_event.clear()
+        return
 
 
 def _normalize_catalog_crop(crop: Optional[str] = None) -> Optional[str]:
@@ -1592,6 +1689,14 @@ async def start_simulation(req: StartRequest):
                 "crop": crop,
                 "rows": total_rows,
                 "time_step": crop_state.get("time_step", req.time_step),
+                "step_sim_duration_seconds": crop_state.get(
+                    "step_sim_duration_seconds"
+                ),
+                "sim_seconds_per_real_second": getattr(
+                    existing_simulator,
+                    "sim_seconds_per_real_second",
+                    crop_state.get("sim_seconds_per_real_second"),
+                ),
                 "dt_minutes": round((crop_state.get("dt_hours") or 0.0) * 60, 3),
             }
 
@@ -1675,23 +1780,27 @@ async def start_simulation(req: StartRequest):
     crop_state["last_runtime_error"] = None
     crop_state["last_runtime_error_at"] = None
     crop_state["last_forecast_schedule_at"] = None
+    crop_state["pace_changed_event"] = None
 
-    # Calculate timestep duration from data
-    if len(df_env) > 1:
-        delta_seconds = max(
-            1.0,
-            (df_env.iloc[1]["datetime"] - df_env.iloc[0]["datetime"]).total_seconds(),
-        )
-        dt_hours = delta_seconds / 3600.0
-        logger.info(
-            f"Calculated timestep duration: {dt_hours:.4f} hours ({dt_hours*60:.1f} minutes)"
-        )
-    else:
-        delta_seconds = 3600.0
-        dt_hours = 1.0
-        logger.warning("Only one row in data, using default dt_hours=1.0")
+    # Calculate timestep duration from the active time-step contract.
+    step_sim_duration_seconds = _derive_step_sim_duration_seconds(req.time_step, df_env)
+    delta_seconds = step_sim_duration_seconds
+    dt_hours = step_sim_duration_seconds / 3600.0
+    logger.info(
+        "Calculated timestep duration: %.4f hours (%.1f minutes)",
+        dt_hours,
+        dt_hours * 60,
+    )
 
     crop_state["dt_hours"] = dt_hours
+    crop_state["step_sim_duration_seconds"] = step_sim_duration_seconds
+    sim_seconds_per_real_second = crop_state.get("sim_seconds_per_real_second")
+    if sim_seconds_per_real_second is None:
+        sim_seconds_per_real_second = _default_sim_seconds_per_real_second(
+            step_sim_duration_seconds
+        )
+        crop_state["sim_seconds_per_real_second"] = sim_seconds_per_real_second
+
     # Forecast sampling tuned to be FASTER than the simulation's 1-hour scale:
     # - base_interval: number of rows per hour (e.g., 10-min data => 6)
     # - Use half-hour equivalent by default (base_interval // 2, but at least 1)
@@ -1733,7 +1842,9 @@ async def start_simulation(req: StartRequest):
         energy_estimator=crop_state["energy"],
         greenhouse_config=greenhouse_config,
         operations_config=ops_config,
-        dt_hours=dt_hours
+        dt_hours=dt_hours,
+        step_sim_duration_seconds=step_sim_duration_seconds,
+        sim_seconds_per_real_second=sim_seconds_per_real_second,
     )
     crop_state["simulator"] = simulator
     if crop_state["irrigation"] is not None:
@@ -1764,8 +1875,8 @@ async def start_simulation(req: StartRequest):
 
     # Auto-start simulation for real-time streaming
     simulator.start()
-    import asyncio
 
+    crop_state["pace_changed_event"] = asyncio.Event()
     crop_state["sim_task"] = asyncio.create_task(_run_simulation_task(crop))
     logger.info(f"{crop} real-time simulation started")
     
@@ -1788,6 +1899,8 @@ async def start_simulation(req: StartRequest):
             "end": str(df_env["datetime"].max()),
         },
         "time_step": req.time_step,
+        "step_sim_duration_seconds": step_sim_duration_seconds,
+        "sim_seconds_per_real_second": sim_seconds_per_real_second,
         "dt_minutes": round(dt_hours * 60, 3),
     }
 
@@ -1973,10 +2086,9 @@ async def _run_simulation_task(crop: str):
                         _record_runtime_error(crop, exc)
                         logger.error("Failed to schedule %s forecast at step %s: %s", crop, i, exc, exc_info=True)
 
-                # Speed-controlled delay (adjustable via simulator.speed)
-                # Default: 0.1s per step (10 steps/sec) for smooth visualization
-                delay = 0.1 / simulator.speed
-                await asyncio.sleep(delay)
+                if i < len(simulator.df_env) - 1:
+                    delay = _simulation_step_delay_seconds(simulator)
+                    await _sleep_simulation_delay(crop, simulator, delay)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -2119,25 +2231,117 @@ async def stop_simulation(crop: Optional[str] = None):
 class SpeedRequest(BaseModel):
     """Request to change simulation speed."""
 
-    speed: float  # Speed multiplier (0.1 to 100)
+    speed: Optional[float] = None  # Legacy speed multiplier (0.1 to 100)
+    sim_seconds_per_real_second: Optional[float] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def prefer_sim_seconds_per_real_second(cls, data):
+        if (
+            isinstance(data, dict)
+            and data.get("sim_seconds_per_real_second") is not None
+        ):
+            try:
+                pace = float(data["sim_seconds_per_real_second"])
+            except (TypeError, ValueError):
+                return {
+                    "sim_seconds_per_real_second": data.get(
+                        "sim_seconds_per_real_second"
+                    )
+                }
+
+            if not math.isfinite(pace) or pace <= 0:
+                return {"sim_seconds_per_real_second": "invalid"}
+
+            return {
+                "sim_seconds_per_real_second": data.get(
+                    "sim_seconds_per_real_second"
+                )
+            }
+
+        if isinstance(data, dict) and data.get("speed") is not None:
+            try:
+                speed = float(data["speed"])
+            except (TypeError, ValueError):
+                return data
+
+            if not math.isfinite(speed):
+                return {"speed": "invalid"}
+
+        return data
+
+    @model_validator(mode="after")
+    def validate_requested_pace(self):
+        if self.speed is None and self.sim_seconds_per_real_second is None:
+            raise ValueError(
+                "Provide speed or sim_seconds_per_real_second"
+            )
+
+        if self.sim_seconds_per_real_second is not None:
+            pace = float(self.sim_seconds_per_real_second)
+            if not math.isfinite(pace) or pace <= 0:
+                raise ValueError(
+                    "sim_seconds_per_real_second must be finite and greater than 0"
+                )
+        elif self.speed is not None and not math.isfinite(float(self.speed)):
+            raise ValueError("speed must be finite")
+
+        return self
 
 
 @app.post("/api/speed")
 async def set_speed(req: SpeedRequest, crop: Optional[str] = None):
     """Set simulation speed."""
     updated_crops = []
+    greenhouse_updates = {}
     for crop_name in _target_crops(crop):
         simulator = app_state[crop_name]["simulator"]
         if simulator is None:
             continue
 
-        simulator.set_speed(req.speed)
+        if req.sim_seconds_per_real_second is not None:
+            sim_seconds_per_real_second = simulator.set_sim_seconds_per_real_second(
+                req.sim_seconds_per_real_second
+            )
+        else:
+            sim_seconds_per_real_second = simulator.set_speed(req.speed)
+
+        app_state[crop_name]["sim_seconds_per_real_second"] = (
+            sim_seconds_per_real_second
+        )
+        app_state[crop_name]["step_sim_duration_seconds"] = getattr(
+            simulator,
+            "step_sim_duration_seconds",
+            app_state[crop_name].get("step_sim_duration_seconds"),
+        )
+        pace_changed_event = app_state[crop_name].get("pace_changed_event")
+        if pace_changed_event is not None:
+            pace_changed_event.set()
+        _record_runtime_tick(crop_name)
         updated_crops.append(crop_name)
+        greenhouse_updates[crop_name] = {
+            "speed": simulator.speed,
+            "sim_seconds_per_real_second": sim_seconds_per_real_second,
+            "step_sim_duration_seconds": getattr(
+                simulator,
+                "step_sim_duration_seconds",
+                None,
+            ),
+        }
 
     if not updated_crops:
         raise HTTPException(status_code=400, detail="Simulation not started")
 
-    return {"status": "success", "crops": updated_crops, "speed": req.speed}
+    first_update = greenhouse_updates[updated_crops[0]]
+    return {
+        "status": "success",
+        "crops": updated_crops,
+        "speed": first_update["speed"],
+        "sim_seconds_per_real_second": first_update[
+            "sim_seconds_per_real_second"
+        ],
+        "greenhouses": greenhouse_updates,
+    }
 
 
 @app.post("/api/config/ops")
@@ -3666,7 +3870,12 @@ async def get_status():
         crop_state = app_state[crop_name]
         
         if crop_state["simulator"] is None:
-            status_result[crop_name] = {"status": "idle"}
+            status_result[crop_name] = {
+                "status": "idle",
+                "sim_seconds_per_real_second": crop_state.get(
+                    "sim_seconds_per_real_second"
+                ),
+            }
         else:
             simulator = crop_state["simulator"]
             sim_task = crop_state.get("sim_task")
@@ -3717,6 +3926,16 @@ async def get_status():
                 "total_rows": total_rows,
                 "progress": progress,
                 "time_step": crop_state.get("time_step", "auto"),
+                "step_sim_duration_seconds": getattr(
+                    simulator,
+                    "step_sim_duration_seconds",
+                    crop_state.get("step_sim_duration_seconds"),
+                ),
+                "sim_seconds_per_real_second": getattr(
+                    simulator,
+                    "sim_seconds_per_real_second",
+                    crop_state.get("sim_seconds_per_real_second"),
+                ),
                 "dt_minutes": round(crop_state.get("dt_hours", 0) * 60, 3)
                 if crop_state.get("dt_hours")
                 else None,

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/simulator.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/simulator.py
@@ -1,6 +1,7 @@
 """Simulation orchestrator managing model execution and state."""
 
 import logging
+import math
 from datetime import datetime
 from typing import Any, Callable, Dict, List
 
@@ -9,6 +10,10 @@ import pandas as pd
 from ..adapters.base import ModelAdapter
 
 logger = logging.getLogger(__name__)
+
+MIN_SIM_SECONDS_PER_REAL_SECOND = 1.0
+MAX_SIM_SECONDS_PER_REAL_SECOND = 86400.0
+LEGACY_REAL_SECONDS_PER_STEP = 0.1
 
 
 class Simulator:
@@ -24,6 +29,8 @@ class Simulator:
         greenhouse_config=None,
         operations_config=None,
         dt_hours: float = 1.0,
+        step_sim_duration_seconds: float | None = None,
+        sim_seconds_per_real_second: float | None = None,
     ):
         """Initialize simulator.
 
@@ -36,6 +43,8 @@ class Simulator:
             greenhouse_config: Optional greenhouse configuration dict
             operations_config: Optional crop-scoped operational settings
             dt_hours: Timestep duration in hours
+            step_sim_duration_seconds: Simulated seconds advanced by one stream step
+            sim_seconds_per_real_second: Simulated seconds advanced per real second
         """
         self.adapter = adapter
         self.broadcast = broadcaster
@@ -45,11 +54,24 @@ class Simulator:
         self.greenhouse_config = greenhouse_config
         self.operations_config = operations_config or {}
         self.dt_hours = dt_hours
+        self.step_sim_duration_seconds = max(
+            1.0,
+            float(
+                step_sim_duration_seconds
+                if step_sim_duration_seconds is not None
+                else dt_hours * 3600.0
+            ),
+        )
 
         self.idx = 0
         self.running = False
         self.paused = False
         self.speed = 1.0  # Speed multiplier (1.0 = real-time, 10.0 = 10x)
+        self.sim_seconds_per_real_second = self._clamp_sim_seconds_per_real_second(
+            sim_seconds_per_real_second
+            if sim_seconds_per_real_second is not None
+            else self._legacy_speed_to_sim_seconds_per_real_second(self.speed)
+        )
 
         logger.info(f"Initialized Simulator with {len(self.df_env)} rows")
 
@@ -74,14 +96,57 @@ class Simulator:
         self.paused = False
         logger.info("Simulator resumed")
 
-    def set_speed(self, speed: float):
+    @staticmethod
+    def _clamp_sim_seconds_per_real_second(value: float) -> float:
+        return max(
+            MIN_SIM_SECONDS_PER_REAL_SECOND,
+            min(MAX_SIM_SECONDS_PER_REAL_SECOND, float(value)),
+        )
+
+    def _legacy_speed_to_sim_seconds_per_real_second(self, speed: float) -> float:
+        return self._clamp_sim_seconds_per_real_second(
+            self.step_sim_duration_seconds * float(speed) / LEGACY_REAL_SECONDS_PER_STEP
+        )
+
+    def set_speed(self, speed: float) -> float:
         """Set simulation speed multiplier.
 
         Args:
             speed: Speed multiplier (1.0 = real-time, 10.0 = 10x)
         """
-        self.speed = max(0.1, min(100.0, speed))
-        logger.info(f"Simulator speed set to {self.speed}x")
+        speed_value = float(speed)
+        if not math.isfinite(speed_value):
+            speed_value = 1.0
+
+        self.speed = max(0.1, min(100.0, speed_value))
+        self.sim_seconds_per_real_second = (
+            self._legacy_speed_to_sim_seconds_per_real_second(self.speed)
+        )
+        logger.info(
+            "Simulator speed set to %sx (%s sim seconds per real second)",
+            self.speed,
+            self.sim_seconds_per_real_second,
+        )
+        return self.sim_seconds_per_real_second
+
+    def set_sim_seconds_per_real_second(self, value: float) -> float:
+        """Set absolute simulation pacing in simulated seconds per real second."""
+        pace = float(value)
+        if not math.isfinite(pace) or pace <= 0:
+            raise ValueError("sim_seconds_per_real_second must be finite and positive")
+
+        self.sim_seconds_per_real_second = self._clamp_sim_seconds_per_real_second(pace)
+        equivalent_speed = (
+            self.sim_seconds_per_real_second
+            * LEGACY_REAL_SECONDS_PER_STEP
+            / max(self.step_sim_duration_seconds, 1e-9)
+        )
+        self.speed = max(0.1, min(100.0, equivalent_speed))
+        logger.info(
+            "Simulator pace set to %s sim seconds per real second",
+            self.sim_seconds_per_real_second,
+        )
+        return self.sim_seconds_per_real_second
 
     def step(self, row: Dict[str, Any]) -> Dict[str, Any]:
         """Execute one simulation step.

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_gitignore_excludes_docs_and_screenshot_artifacts() -> None:
+    patterns = {
+        line.strip()
+        for line in Path(".gitignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+    assert "docs/" in patterns
+    assert "screenshots/" in patterns
+    assert "*.screenshot.png" in patterns
+    assert "*.screenshot.jpg" in patterns
+    assert "*.screenshot.jpeg" in patterns

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -50,6 +50,9 @@ def reset_runtime_state() -> None:
         crop_state["sim_task"] = None
         crop_state["dt_hours"] = None
         crop_state["time_step"] = "auto"
+        crop_state["step_sim_duration_seconds"] = None
+        crop_state["sim_seconds_per_real_second"] = None
+        crop_state["pace_changed_event"] = None
         crop_state["decision"] = None
         crop_state["last_irrigation"] = None
         crop_state["last_energy"] = None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,12 +1,54 @@
 import asyncio
 import time
+from types import SimpleNamespace
 
 import pandas as pd
 from fastapi.testclient import TestClient
+import pytest
 
 from model_informed_greenhouse_dashboard import get_app
 from model_informed_greenhouse_dashboard.backend.app import main as backend_main
+from model_informed_greenhouse_dashboard.backend.app.services.simulator import Simulator
 from model_informed_greenhouse_dashboard.backend.app.ws import ConnectionManager
+
+
+def _reset_streaming_app_state() -> None:
+    for crop in ("tomato", "cucumber"):
+        crop_state = backend_main.app_state[crop]
+        crop_state["simulator"] = None
+        crop_state["forecaster"] = None
+        crop_state["irrigation"] = None
+        crop_state["energy"] = None
+        crop_state["adapter"] = None
+        crop_state["df_env"] = None
+        crop_state["sim_task"] = None
+        crop_state["dt_hours"] = None
+        crop_state["time_step"] = "auto"
+        crop_state["step_sim_duration_seconds"] = None
+        crop_state["sim_seconds_per_real_second"] = None
+        crop_state["pace_changed_event"] = None
+        crop_state["decision"] = None
+        crop_state["last_irrigation"] = None
+        crop_state["last_energy"] = None
+        crop_state["latest_forecast"] = None
+        crop_state["last_forecast_schedule_at"] = None
+        crop_state["ops_config"] = None
+        crop_state["crop_config"] = None
+        crop_state["csv_filename"] = None
+        crop_state["pending_prune_reset"] = False
+        crop_state["last_runtime_snapshot_at"] = None
+        crop_state["last_runtime_tick_at"] = None
+        crop_state["last_runtime_error"] = None
+        crop_state["last_runtime_error_at"] = None
+
+    backend_main.manager.active_connections.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_streaming_state() -> None:
+    _reset_streaming_app_state()
+    yield
+    _reset_streaming_app_state()
 
 
 class DummySimulator:
@@ -36,6 +78,34 @@ class DummyIrrigation:
 class DummyEnergy:
     def estimate_step(self, **kwargs) -> dict:  # noqa: ANN003
         return {"P_elec_kW": 4.2, "COP_current": 3.6, "kwargs": kwargs}
+
+
+def _make_simulator(
+    *,
+    step_sim_duration_seconds: float = 600.0,
+    sim_seconds_per_real_second: float = 6000.0,
+) -> Simulator:
+    return Simulator(
+        adapter=SimpleNamespace(model=SimpleNamespace(cumulative_thermal_time=123.0)),
+        broadcaster=lambda path, payload: None,
+        df_env=pd.DataFrame(
+            {
+                "datetime": pd.date_range(
+                    "2026-04-03T09:00:00",
+                    periods=10,
+                    freq="10min",
+                )
+            }
+        ),
+        dt_hours=step_sim_duration_seconds / 3600.0,
+        step_sim_duration_seconds=step_sim_duration_seconds,
+        sim_seconds_per_real_second=sim_seconds_per_real_second,
+    )
+
+
+class LiveTask:
+    def done(self) -> bool:
+        return False
 
 
 def test_step_endpoint_broadcasts_single_crop_payload(monkeypatch) -> None:
@@ -118,3 +188,244 @@ def test_broadcast_drops_slow_clients_without_blocking_all_peers() -> None:
     assert elapsed < 1.5
     assert sent_payloads == ['fast:{"status": "ok"}']
     assert slow_socket not in manager.active_connections[path]
+
+
+def test_verify_src001_s0002_r001_a01_stream_delay_uses_step_duration_over_pace(
+    monkeypatch,
+) -> None:
+    class DelayProbeSimulator:
+        def __init__(self) -> None:
+            self.idx = 0
+            self.running = True
+            self.paused = False
+            self.dt_hours = 1 / 6
+            self.step_sim_duration_seconds = 600.0
+            self.sim_seconds_per_real_second = 1200.0
+            self.speed = 100.0
+            self.df_env = pd.DataFrame(
+                [
+                    {"datetime": pd.Timestamp("2026-04-03T09:00:00")},
+                    {"datetime": pd.Timestamp("2026-04-03T09:10:00")},
+                ]
+            )
+
+        def step_from_index(self, idx: int) -> dict:
+            self.idx = idx
+            return {
+                "t": "2026-04-03T09:00:00",
+                "crop": "tomato",
+                "kpi": {},
+                "env": {"T_air_C": 21.5},
+                "state": {"datetime": "2026-04-03T09:00:00"},
+            }
+
+        def stop(self) -> None:
+            self.running = False
+
+    sleep_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    async def fake_broadcast(path: str, payload: dict) -> None:
+        return None
+
+    backend_main.app_state["tomato"]["simulator"] = DelayProbeSimulator()
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(backend_main.manager, "broadcast", fake_broadcast)
+    monkeypatch.setattr(
+        backend_main,
+        "_maybe_persist_runtime_snapshot",
+        lambda *args, **kwargs: None,
+    )
+
+    asyncio.run(backend_main._run_simulation_task("tomato"))
+
+    assert sleep_delays == [0.5]
+
+
+def test_pace_change_event_wakes_active_stream_delay() -> None:
+    class SleepingSimulator:
+        running = True
+
+    async def run_sleep() -> None:
+        event = asyncio.Event()
+        backend_main.app_state["tomato"]["pace_changed_event"] = event
+        sleeper = asyncio.create_task(
+            backend_main._sleep_simulation_delay(
+                "tomato",
+                SleepingSimulator(),
+                60.0,
+            )
+        )
+        await asyncio.sleep(0)
+        event.set()
+        await asyncio.wait_for(sleeper, timeout=1.0)
+
+    asyncio.run(run_sleep())
+
+
+def test_verify_src001_s0002_r002_a01_explicit_time_step_maps_to_step_duration() -> None:
+    df_env = pd.DataFrame(
+        {"datetime": pd.date_range("2026-04-03T09:00:00", periods=2, freq="10min")}
+    )
+
+    assert backend_main._derive_step_sim_duration_seconds("1s", df_env) == 1.0
+    assert backend_main._derive_step_sim_duration_seconds("1min", df_env) == 60.0
+    assert backend_main._derive_step_sim_duration_seconds("10min", df_env) == 600.0
+    assert backend_main._derive_step_sim_duration_seconds("1h", df_env) == 3600.0
+
+
+def test_verify_src001_s0002_r002_a02_auto_time_step_uses_median_timestamp_gap() -> None:
+    df_env = pd.DataFrame(
+        {
+            "datetime": [
+                "2026-04-03T09:00:00",
+                "2026-04-03T09:01:00",
+                "2026-04-03T09:11:00",
+                "2026-04-03T09:21:00",
+            ]
+        }
+    )
+
+    assert backend_main._derive_step_sim_duration_seconds("auto", df_env) == 600.0
+
+
+def test_verify_src001_s0002_r003_a01_a02_speed_endpoint_accepts_legacy_and_prefers_new() -> None:
+    simulator = _make_simulator(step_sim_duration_seconds=600.0)
+    backend_main.app_state["tomato"]["simulator"] = simulator
+    client = TestClient(get_app())
+
+    legacy_response = client.post("/api/speed?crop=tomato", json={"speed": 2.0})
+    assert legacy_response.status_code == 200
+    assert legacy_response.json()["sim_seconds_per_real_second"] == 12000.0
+    assert simulator.sim_seconds_per_real_second == 12000.0
+
+    priority_response = client.post(
+        "/api/speed?crop=tomato",
+        json={"speed": 99.0, "sim_seconds_per_real_second": 300.0},
+    )
+    assert priority_response.status_code == 200
+    assert priority_response.json()["sim_seconds_per_real_second"] == 300.0
+    assert simulator.sim_seconds_per_real_second == 300.0
+
+    invalid_legacy_response = client.post(
+        "/api/speed?crop=tomato",
+        json={"speed": "not-a-number", "sim_seconds_per_real_second": 42.0},
+    )
+    assert invalid_legacy_response.status_code == 200
+    assert invalid_legacy_response.json()["sim_seconds_per_real_second"] == 42.0
+
+
+@pytest.mark.parametrize(
+    "raw_payload",
+    [
+        '{"speed": NaN}',
+        '{"speed": Infinity}',
+    ],
+)
+def test_legacy_speed_rejects_non_finite_values_without_mutation(raw_payload: str) -> None:
+    simulator = _make_simulator(
+        step_sim_duration_seconds=600.0,
+        sim_seconds_per_real_second=6000.0,
+    )
+    backend_main.app_state["tomato"]["simulator"] = simulator
+    client = TestClient(get_app())
+
+    response = client.post(
+        "/api/speed?crop=tomato",
+        content=raw_payload,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert simulator.sim_seconds_per_real_second == 6000.0
+
+
+def test_verify_src001_s0002_r004_a01_sim_seconds_per_real_second_is_clamped() -> None:
+    simulator = _make_simulator(step_sim_duration_seconds=600.0)
+    backend_main.app_state["tomato"]["simulator"] = simulator
+    client = TestClient(get_app())
+
+    low_response = client.post(
+        "/api/speed?crop=tomato",
+        json={"sim_seconds_per_real_second": 0.5},
+    )
+    assert low_response.status_code == 200
+    assert low_response.json()["sim_seconds_per_real_second"] == 1.0
+
+    high_response = client.post(
+        "/api/speed?crop=tomato",
+        json={"sim_seconds_per_real_second": 1_000_000.0},
+    )
+    assert high_response.status_code == 200
+    assert high_response.json()["sim_seconds_per_real_second"] == 86400.0
+
+
+@pytest.mark.parametrize(
+    "raw_payload",
+    [
+        '{"sim_seconds_per_real_second": 0}',
+        '{"sim_seconds_per_real_second": -1}',
+        '{"sim_seconds_per_real_second": NaN}',
+        '{"sim_seconds_per_real_second": Infinity}',
+    ],
+)
+def test_verify_src001_s0002_r005_a01_invalid_sim_seconds_return_422_without_mutation(
+    raw_payload: str,
+) -> None:
+    simulator = _make_simulator(
+        step_sim_duration_seconds=600.0,
+        sim_seconds_per_real_second=6000.0,
+    )
+    backend_main.app_state["tomato"]["simulator"] = simulator
+    client = TestClient(get_app())
+
+    response = client.post(
+        "/api/speed?crop=tomato",
+        content=raw_payload,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert simulator.sim_seconds_per_real_second == 6000.0
+
+
+def test_verify_src001_s0002_r006_a01_speed_change_preserves_runtime_and_websockets() -> None:
+    simulator = _make_simulator(step_sim_duration_seconds=600.0)
+    simulator.idx = 7
+    simulator.start()
+    backend_main.app_state["tomato"]["simulator"] = simulator
+    backend_main.app_state["tomato"]["adapter"] = simulator.adapter
+    backend_main.app_state["tomato"]["sim_task"] = LiveTask()
+    socket = object()
+    backend_main.manager.active_connections["/ws/sim/tomato"] = {socket}
+
+    response = TestClient(get_app()).post(
+        "/api/speed?crop=tomato",
+        json={"sim_seconds_per_real_second": 7200.0},
+    )
+
+    assert response.status_code == 200
+    assert simulator.idx == 7
+    assert simulator.adapter.model.cumulative_thermal_time == 123.0
+    assert backend_main.manager.active_connections["/ws/sim/tomato"] == {socket}
+
+
+def test_verify_src001_s0002_r007_a01_status_includes_current_sim_seconds_per_real_second() -> None:
+    simulator = _make_simulator(
+        step_sim_duration_seconds=600.0,
+        sim_seconds_per_real_second=4321.0,
+    )
+    simulator.start()
+    backend_main.app_state["cucumber"]["simulator"] = simulator
+    backend_main.app_state["cucumber"]["sim_task"] = LiveTask()
+    backend_main.app_state["cucumber"]["time_step"] = "10min"
+    backend_main.app_state["cucumber"]["dt_hours"] = 1 / 6
+
+    response = TestClient(get_app()).get("/api/status")
+
+    assert response.status_code == 200
+    cucumber = response.json()["greenhouses"]["cucumber"]
+    assert cucumber["sim_seconds_per_real_second"] == 4321.0
+    assert cucumber["step_sim_duration_seconds"] == 600.0


### PR DESCRIPTION
## Summary
Fixes the runaway simulation (1 real second ≈ 100 simulated minutes) by introducing a user-meaningful pacing contract and control, and audits every first-class route for layout defects.

- Backend: stream delay becomes `step_sim_duration_seconds / sim_seconds_per_real_second`; `POST /api/speed` accepts the new field (legacy `speed` multiplier stays backward compatible, clamp 1–86400, HTTP 422 on invalid values without mutation); `/api/status` exposes the effective pace.
- Frontend: SPEED presets ×10/20/30/60/600/6000 (sim-seconds per real second) on the runtime panel; selection POSTs `/api/speed` and only persists (`localStorage` `sg-sim-pace`) on success; stored pace is re-applied on WebSocket (re)connect; pause/resume wired to the existing endpoints; initial default 600.
- Repo: screenshot ignore policy + repository policy test.
- Includes `6a649f7` (backend hotfix): removed eight function-local `import asyncio` statements that made fresh `POST /api/start` crash with `UnboundLocalError` (regression guard test added; live-verified fresh start works). Note: this commit currently sits on the fix/135 branch tip in the stack.

## Decisions
Pace is expressed as "simulated seconds per real second" instead of the old opaque 0.1–100 multiplier; default 600 (1 s → 10 min) keeps charts readable while presets cover the legacy 6000 behavior.

## Validation
- `tests/test_streaming.py` 17 tests (pace mapping per `time_step`, clamp bounds, 422-without-mutation, WS/idx preservation), full backend `pytest` green, `ruff` clean.
- Frontend vitest suite green including preset render/POST/persist/failure-path tests; lint 0; build 0.
- Full-route visual audit: 27 Playwright captures (9 routes × 3 viewports) with live telemetry, no overlap/clipping/overflow found (ledger + captures under local `docs/architecture/implementation/`).

## Risk / rollback
Backward-compatible `/api/speed`; revert this PR to restore the fixed 10-steps/s pace. No schema/data changes.

Closes #131
