### PR TITLE
fix: repair landing nav dead anchors and modernize the trend route frame

### DIFF
--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -666,8 +666,8 @@ describe('App routed shell', () => {
     expect(screen.queryByTestId('topbar-title')).toBeNull()
     expect(screen.getByRole('button', { name: 'Open assistant fab' })).toBeTruthy()
     expect(screen.getByRole('navigation', { name: 'PhytoSync landing navigation' })).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/overview#overview-dashboard')
-    expect(screen.getByRole('link', { name: 'View Dashboard' }).getAttribute('href')).toBe('/overview#overview-dashboard')
+    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/control')
+    expect(screen.getByRole('link', { name: 'View Dashboard' }).getAttribute('href')).toBe('/control')
     expect(screen.getByRole('button', { name: 'Ask Assistant' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'AI decision platform for smart greenhouses.' })).toBeTruthy()
 
@@ -784,14 +784,15 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('rtr-optimizer-state').textContent).toBe('0.73|balanced')
   })
 
-  it('keeps overview dashboard anchors on the standalone landing navigation', async () => {
+  it('routes standalone landing navigation to live surfaces without dead hash anchors', async () => {
     renderApp('/overview')
 
     expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull()
-    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/overview#overview-dashboard')
+    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/control')
     expect(screen.getByRole('link', { name: 'INSIGHTS' }).getAttribute('href')).toBe('/trend')
     expect(screen.getByRole('link', { name: 'SCENARIOS' }).getAttribute('href')).toBe('/scenarios')
-    expect(screen.getByRole('link', { name: 'KNOWLEDGE' }).getAttribute('href')).toBe('/assistant#assistant-search')
+    expect(screen.getByRole('link', { name: 'KNOWLEDGE' }).getAttribute('href')).toBe('/assistant')
+    expect(screen.getByRole('button', { name: 'CONTACT' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'AI decision platform for smart greenhouses.' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Live decision metrics' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Actions worth checking today' })).toBeTruthy()

--- a/frontend/src/components/charts/ChartFrame.tsx
+++ b/frontend/src/components/charts/ChartFrame.tsx
@@ -50,7 +50,10 @@ export default function ChartFrame({
     return (
         <div
             ref={containerRef}
-            className={cn('w-full', className)}
+            // min-w-0 lets the frame shrink below the chart's intrinsic width when it
+            // is a flex/grid item, so the measured width tracks the container on narrow
+            // viewports instead of forcing horizontal page overflow.
+            className={cn('w-full min-w-0', className)}
             style={{ minHeight, ...style }}
         >
             {isReady ? (

--- a/frontend/src/components/dashboard/overviewLandingSections.test.tsx
+++ b/frontend/src/components/dashboard/overviewLandingSections.test.tsx
@@ -169,14 +169,29 @@ describe('overview landing sections', () => {
     expect(screen.queryByText('AI decision platform for smart greenhouses.')).toBeNull();
   });
 
-  it('routes landing navigation to the full feature surfaces', () => {
+  it('routes landing navigation to live feature surfaces without dead hash anchors', () => {
     renderWithProviders(<TopNavigation onOpenAssistant={() => undefined} />);
 
-    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/overview#overview-dashboard');
+    // Regression guard for issue #132: these previously pointed at #overview-dashboard
+    // and #assistant-search anchors that do not exist on the standalone routes.
+    expect(screen.getByRole('link', { name: 'HOME' }).getAttribute('href')).toBe('/overview');
+    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/control');
     expect(screen.getByRole('link', { name: 'INSIGHTS' }).getAttribute('href')).toBe('/trend');
     expect(screen.getByRole('link', { name: 'SCENARIOS' }).getAttribute('href')).toBe('/scenarios');
-    expect(screen.getByRole('link', { name: 'KNOWLEDGE' }).getAttribute('href')).toBe('/assistant#assistant-search');
+    expect(screen.getByRole('link', { name: 'KNOWLEDGE' }).getAttribute('href')).toBe('/assistant');
     expect(screen.getByRole('button', { name: 'Ask Assistant' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Open Dashboard' }).getAttribute('href')).toBe('/overview#overview-dashboard');
+    // CONTACT is an in-page action (scrolls to the footer), not a route link.
+    expect(screen.getByRole('button', { name: 'CONTACT' })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'CONTACT' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Open Dashboard' }).getAttribute('href')).toBe('/control');
+  });
+
+  it('does not reintroduce dead hash-anchor navigation targets', () => {
+    renderWithProviders(<TopNavigation onOpenAssistant={() => undefined} />);
+
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.getAttribute('href') ?? '').not.toContain('#overview-dashboard');
+      expect(link.getAttribute('href') ?? '').not.toContain('#assistant-search');
+    }
   });
 });

--- a/frontend/src/components/dashboard/overviewLandingSections.tsx
+++ b/frontend/src/components/dashboard/overviewLandingSections.tsx
@@ -130,15 +130,27 @@ interface TopNavigationProps {
   onOpenAssistant: () => void;
 }
 
+type LandingNavItem = { label: string; to?: string; onClick?: () => void };
+
+function scrollToLandingFooter() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.getElementById('overview-footer')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
 export function TopNavigation({ onOpenAssistant }: TopNavigationProps) {
   const { locale } = useLocale();
-  const nav = [
-    ['HOME', '/overview'],
-    ['DASHBOARD', '/overview#overview-dashboard'],
-    ['INSIGHTS', '/trend'],
-    ['SCENARIOS', '/scenarios'],
-    ['KNOWLEDGE', '/assistant#assistant-search'],
-    ['CONTACT', '/settings'],
+  // Every item resolves to a live destination: hash anchors that only existed on the
+  // retired tabbed overview page were dead, so DASHBOARD/KNOWLEDGE now use real routes
+  // and CONTACT scrolls to the footer contact block.
+  const nav: LandingNavItem[] = [
+    { label: 'HOME', to: '/overview' },
+    { label: 'DASHBOARD', to: '/control' },
+    { label: 'INSIGHTS', to: '/trend' },
+    { label: 'SCENARIOS', to: '/scenarios' },
+    { label: 'KNOWLEDGE', to: '/assistant' },
+    { label: 'CONTACT', onClick: scrollToLandingFooter },
   ];
   const assistantLabel = locale === 'ko' ? '질문하기' : 'Ask Assistant';
   const dashboardLabel = locale === 'ko' ? '대시보드 열기' : 'Open Dashboard';
@@ -151,14 +163,25 @@ export function TopNavigation({ onOpenAssistant }: TopNavigationProps) {
           PhytoSync
         </Link>
         <div className="overview-nav-links">
-          {nav.map(([label, to]) => (
-            <Link
-              key={label}
-              to={to}
-              className="overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
-            >
-              {label}
-            </Link>
+          {nav.map((item) => (
+            item.to ? (
+              <Link
+                key={item.label}
+                to={item.to}
+                className="overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <button
+                key={item.label}
+                type="button"
+                onClick={item.onClick}
+                className="overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
+              >
+                {item.label}
+              </button>
+            )
           ))}
         </div>
         <div className="flex items-center justify-end gap-2">
@@ -171,7 +194,7 @@ export function TopNavigation({ onOpenAssistant }: TopNavigationProps) {
             <MessageCircle className="h-4 w-4" aria-hidden="true" />
           </button>
           <Link
-            to="/overview#overview-dashboard"
+            to="/control"
             className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-[var(--sg-radius-sm)] bg-[color:var(--sg-color-primary)] px-3.5 text-xs font-bold text-white shadow-[var(--sg-shadow-card)] transition hover:bg-[color:var(--sg-color-primary-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)] focus-visible:ring-offset-2"
           >
             {dashboardLabel} <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
@@ -211,7 +234,7 @@ export function HeroDecisionBrief({ heroCard }: { heroCard: ReactNode }) {
           {copy.support}
         </p>
         <div className="mt-2.5 flex flex-wrap gap-2.5">
-          <Link className="inline-flex h-8 items-center justify-center rounded-[var(--sg-radius-sm)] bg-[color:var(--sg-color-primary)] px-3.5 text-xs font-bold text-white shadow-[var(--sg-shadow-card)] hover:bg-[color:var(--sg-color-primary-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)] focus-visible:ring-offset-2" to="/overview#overview-dashboard">
+          <Link className="inline-flex h-8 items-center justify-center rounded-[var(--sg-radius-sm)] bg-[color:var(--sg-color-primary)] px-3.5 text-xs font-bold text-white shadow-[var(--sg-shadow-card)] hover:bg-[color:var(--sg-color-primary-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)] focus-visible:ring-offset-2" to="/control">
             {copy.primary}
           </Link>
           <Link className="inline-flex h-8 items-center justify-center rounded-[var(--sg-radius-sm)] border border-[color:var(--sg-color-primary)] bg-white px-3.5 text-xs font-bold text-[color:var(--sg-color-primary)] shadow-[var(--sg-shadow-card)] hover:bg-[color:var(--sg-color-primary-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)] focus-visible:ring-offset-2" to="/scenarios">
@@ -948,7 +971,7 @@ export function LandingFooter({ onOpenAssistant }: { onOpenAssistant: () => void
       };
 
   return (
-    <footer className="flex flex-col gap-2 border-t border-[color:var(--sg-outline-soft)] py-2 text-xs text-[color:var(--sg-text-muted)] md:flex-row md:items-center md:justify-between">
+    <footer id="overview-footer" className="flex flex-col gap-2 border-t border-[color:var(--sg-outline-soft)] py-2 text-xs text-[color:var(--sg-text-muted)] md:flex-row md:items-center md:justify-between">
       <div className="flex items-center gap-2 font-semibold text-[color:var(--sg-text-strong)]">
         <Leaf className="h-4 w-4 text-[color:var(--sg-color-olive)]" aria-hidden="true" />
         PhytoSync

--- a/frontend/src/pages/trend-page.tsx
+++ b/frontend/src/pages/trend-page.tsx
@@ -1,20 +1,84 @@
 import type { ReactNode } from 'react';
 import PageCanvas from '../components/layout/PageCanvas';
+import { SectionHeader } from '../components/ui/section-header';
+import type { AppLocale } from '../i18n/locale';
 
 interface TrendPageProps {
+  locale: AppLocale;
   weatherSurface: ReactNode;
   marketSurface: ReactNode;
   decisionSurface?: ReactNode;
 }
 
-export default function TrendPage({ weatherSurface, marketSurface, decisionSurface = null }: TrendPageProps) {
+export default function TrendPage({
+  locale,
+  weatherSurface,
+  marketSurface,
+  decisionSurface = null,
+}: TrendPageProps) {
+  const copy = locale === 'ko'
+    ? {
+        eyebrow: '인사이트',
+        title: '외기·시세 인사이트',
+        description: '대구 외기 추세와 도매 시세를 한 화면에서 비교해 오늘의 관수·환기·출하 판단을 준비합니다.',
+        weatherEyebrow: '외기',
+        weatherTitle: '외기 추세와 3일 예보',
+        weatherDescription: '기온·강수·일사·풍속 추세와 단기 예보를 함께 봅니다.',
+        marketEyebrow: '시세',
+        marketTitle: '도매 시세 추세',
+        marketDescription: '주요 품목의 도매 평균가와 2주 추세선을 확인합니다.',
+        decisionEyebrow: '의사결정',
+        decisionTitle: '의사결정 스냅샷',
+        decisionDescription: '외기·시세·에너지·생육 신호를 묶어 지금의 상황을 요약합니다.',
+      }
+    : {
+        eyebrow: 'Insights',
+        title: 'Weather & market insights',
+        description: 'Compare regional weather trends and wholesale prices on one screen to prepare today irrigation, ventilation, and shipping decisions.',
+        weatherEyebrow: 'Weather',
+        weatherTitle: 'Weather trend & 3-day outlook',
+        weatherDescription: 'Temperature, rainfall, radiation, and wind trends alongside the short-term forecast.',
+        marketEyebrow: 'Market',
+        marketTitle: 'Wholesale price trend',
+        marketDescription: 'Wholesale average prices and the two-week trend line for key produce.',
+        decisionEyebrow: 'Decision',
+        decisionTitle: 'Decision snapshot',
+        decisionDescription: 'Weather, market, energy, and growth signals combined into a current-state summary.',
+      };
+
   return (
-    <PageCanvas title="Trend" description="" hideHeader>
-      <div className="grid grid-cols-1 items-start gap-5 xl:grid-cols-12">
-        <div className="min-h-0 xl:col-span-12">{weatherSurface}</div>
-        <div className="min-h-0 xl:col-span-12">{marketSurface}</div>
-        {decisionSurface ? <div className="min-h-0 xl:col-span-12">{decisionSurface}</div> : null}
-      </div>
+    <PageCanvas eyebrow={copy.eyebrow} title={copy.title} description={copy.description}>
+      <section className="grid gap-4" aria-labelledby="trend-weather-title">
+        <SectionHeader
+          eyebrow={copy.weatherEyebrow}
+          title={copy.weatherTitle}
+          description={copy.weatherDescription}
+          titleId="trend-weather-title"
+        />
+        {weatherSurface}
+      </section>
+
+      <section className="grid gap-4" aria-labelledby="trend-market-title">
+        <SectionHeader
+          eyebrow={copy.marketEyebrow}
+          title={copy.marketTitle}
+          description={copy.marketDescription}
+          titleId="trend-market-title"
+        />
+        {marketSurface}
+      </section>
+
+      {decisionSurface ? (
+        <section className="grid gap-4" aria-labelledby="trend-decision-title">
+          <SectionHeader
+            eyebrow={copy.decisionEyebrow}
+            title={copy.decisionTitle}
+            description={copy.decisionDescription}
+            titleId="trend-decision-title"
+          />
+          {decisionSurface}
+        </section>
+      ) : null}
     </PageCanvas>
   );
 }

--- a/frontend/src/pages/trend-route-page.tsx
+++ b/frontend/src/pages/trend-route-page.tsx
@@ -29,6 +29,7 @@ interface TrendRoutePageProps {
 }
 
 export default function TrendRoutePage({
+  locale,
   crop,
   currentData,
   modelMetrics,
@@ -43,6 +44,7 @@ export default function TrendRoutePage({
 }: TrendRoutePageProps) {
   return (
     <TrendPage
+      locale={locale}
       weatherSurface={(
         <div className="grid gap-5">
           <WeatherTrendPanel


### PR DESCRIPTION
## Summary
Repairs the landing navigation dead-ends and modernizes the INSIGHTS route frame.

- Landing nav: DASHBOARD/KNOWLEDGE pointed at hash anchors that only existed on the retired tabbed overview (`#overview-dashboard`, `#assistant-search`) so clicks changed the URL but went nowhere; they now target `/control` and `/assistant`, CONTACT scrolls to the footer contact block, and the hero/header dashboard CTAs follow. Regression tests guard against reintroducing dead anchors.
- `/trend` gets a real `PageCanvas` header plus labeled weather/market/decision `SectionHeader` sections (was `hideHeader` + unframed stacks).
- `ChartFrame` gains `min-w-0` so charts shrink below intrinsic width — fixes a 390px horizontal page overflow on `/trend` (verified no regression on `/control`, `/rtr`).

## Validation
Playwright click-through of every nav item (URL + rendered content), mobile overflow re-measured (scrollWidth 909→375 at 390px); frontend lint/test/build green.

## Risk / rollback
Pure frontend; revert restores previous targets. Depends on #131 branch (stacked PR).

Refs #132
