### PR TITLE
feat: grower-friendly copy, two-tier navigation, and panel dedup

### DIFF
--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -365,44 +365,88 @@ vi.mock('./components/shell/TopBar', () => ({
 
 vi.mock('./components/shell/WorkspaceTopNav', () => ({
   default: ({
+    globalItems,
     items,
+    activeGlobalKey,
     activeWorkspace,
     activeActionId,
+    onSelectGlobal,
+    onSelectContact,
     onSelect,
     onSelectAction,
   }: {
+    globalItems: Array<{ key: string; label: string; path?: string }>
     items: Array<{ key: string; label: string; actions?: Array<{ id: string; label: string }> }>
+    activeGlobalKey?: string | null
     activeWorkspace: string
     activeActionId?: string
+    onSelectGlobal?: (value: string) => void
+    onSelectContact?: () => void
     onSelect: (value: string) => void
     onSelectAction?: (workspace: string, actionId: string) => void
-  }) => (
-    <nav aria-label="Primary navigation">
-      {items.map((item) => (
-        <div key={item.key}>
-          <button
-            type="button"
-            aria-current={item.key === activeWorkspace ? 'page' : undefined}
-            onClick={() => onSelect(item.key)}
-          >
-            {item.label}
-          </button>
-          {item.key === activeWorkspace
-            ? item.actions?.map((action) => (
+  }) => {
+    const globalTargetByKey: Record<string, string> = {
+      home: 'overview',
+      dashboard: 'control',
+      insights: 'trend',
+      scenarios: 'scenarios',
+      knowledge: 'assistant',
+    }
+    const activeItem = items.find((item) => item.key === activeWorkspace)
+
+    return (
+      <div>
+        <nav aria-label="Global navigation">
+          {globalItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              aria-current={item.key === activeGlobalKey ? 'page' : undefined}
+              onClick={() => {
+                if (item.key === 'contact') {
+                  onSelectContact?.()
+                  return
+                }
+                onSelectGlobal?.(item.key)
+                onSelect(globalTargetByKey[item.key] ?? 'overview')
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+        {items.length > 0 ? (
+          <nav aria-label="Category subtab navigation">
+            {items.map((item) => (
+              <div key={item.key}>
                 <button
-                  key={action.id}
                   type="button"
-                  aria-current={activeActionId === action.id ? 'step' : undefined}
-                  onClick={() => onSelectAction?.(item.key, action.id)}
+                  aria-current={item.key === activeWorkspace ? 'step' : undefined}
+                  onClick={() => onSelect(item.key)}
                 >
-                  {`Action:${action.id}`}
+                  {item.label}
                 </button>
-              ))
-            : null}
-        </div>
-      ))}
-    </nav>
-  ),
+              </div>
+            ))}
+          </nav>
+        ) : null}
+        {activeItem?.actions?.length ? (
+          <nav aria-label="Panel action navigation">
+            {activeItem.actions.map((action) => (
+              <button
+                key={action.id}
+                type="button"
+                aria-pressed={activeActionId === action.id}
+                onClick={() => onSelectAction?.(activeItem.key, action.id)}
+              >
+                {`Action:${action.id}`}
+              </button>
+            ))}
+          </nav>
+        ) : null}
+      </div>
+    )
+  },
 }))
 
 vi.mock('./components/dashboard/HeroControlCard', () => ({
@@ -716,7 +760,8 @@ describe('App routed shell', () => {
     expect(await screen.findByRole('heading', { name: 'Assistant' })).toBeTruthy()
     expect(screen.getByText('AskSearchPage:assistant-chat')).toBeTruthy()
     expect(screen.queryByRole('heading', { name: 'Today operations' })).toBeNull()
-    expect(screen.getByRole('button', { name: 'Assistant' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'KNOWLEDGE' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Assistant' }).getAttribute('aria-current')).toBe('step')
     expect(screen.queryByRole('button', { name: 'Open assistant fab' })).toBeNull()
   })
 
@@ -812,13 +857,14 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
     expect(screen.getByRole('button', { name: 'Open assistant fab' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Control' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DASHBOARD' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('topbar-title').textContent).toBe('Control Solutions')
     })
     expect(await screen.findByText('RTROptimizerPanel', {}, { timeout: 5000 })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
   }, 15000)
 
   it('keeps RTR state outside route-local control pages', async () => {
@@ -827,12 +873,12 @@ describe('App routed shell', () => {
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByTestId('rtr-optimizer-state').textContent).toBe('0.73|balanced')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trend' }))
+    fireEvent.click(screen.getByRole('button', { name: 'INSIGHTS' }))
     await waitFor(() => {
       expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Control' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DASHBOARD' }))
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByTestId('rtr-optimizer-state').textContent).toBe('0.73|balanced')
   })
@@ -844,12 +890,12 @@ describe('App routed shell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Persist RTR draft' }))
     expect(screen.getByTestId('rtr-ui-state').textContent).toBe('0.81')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trend' }))
+    fireEvent.click(screen.getByRole('button', { name: 'INSIGHTS' }))
     await waitFor(() => {
       expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Control' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DASHBOARD' }))
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByTestId('rtr-ui-state').textContent).toBe('0.81')
   })
@@ -911,6 +957,7 @@ describe('App routed shell', () => {
     renderApp('/overview')
 
     expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull()
+    expect(screen.getByRole('link', { name: 'HOME' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/control')
     expect(screen.getByRole('link', { name: 'INSIGHTS' }).getAttribute('href')).toBe('/trend')
     expect(screen.getByRole('link', { name: 'SCENARIOS' }).getAttribute('href')).toBe('/scenarios')
@@ -919,6 +966,62 @@ describe('App routed shell', () => {
     expect(screen.getByRole('region', { name: 'AI decision platform for smart greenhouses.' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Live decision metrics' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Actions worth checking today' })).toBeTruthy()
+  })
+
+  it('verify_src001_s0002_r001_a01 renders the same global navigation on routed workspace screens', async () => {
+    renderApp('/control')
+
+    const globalNav = screen.getByRole('navigation', { name: 'Global navigation' })
+    expect(globalNav.textContent).toContain('HOME')
+    expect(globalNav.textContent).toContain('DASHBOARD')
+    expect(globalNav.textContent).toContain('INSIGHTS')
+    expect(globalNav.textContent).toContain('SCENARIOS')
+    expect(globalNav.textContent).toContain('KNOWLEDGE')
+    expect(globalNav.textContent).toContain('CONTACT')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
+  })
+
+  it('verify_src001_s0002_r003_a01 keeps only the active parent category subtabs visible', async () => {
+    renderApp('/control')
+
+    const categoryNav = screen.getByRole('navigation', { name: 'Category subtab navigation' })
+    expect(categoryNav.textContent).toContain('Control')
+    expect(categoryNav.textContent).toContain('RTR Optimizer')
+    expect(categoryNav.textContent).toContain('Crop Work')
+    expect(categoryNav.textContent).toContain('Resources')
+    expect(categoryNav.textContent).toContain('Alerts')
+    expect(categoryNav.textContent).not.toContain('Trend')
+    expect(categoryNav.textContent).not.toContain('Scenario')
+    expect(categoryNav.textContent).not.toContain('Assistant')
+    expect(categoryNav.textContent).not.toContain('Settings')
+  })
+
+  it('verify_src001_s0002_r004_a01 removes the old flat ten-item workspace strip', async () => {
+    renderApp('/trend')
+
+    const categoryNav = screen.getByRole('navigation', { name: 'Category subtab navigation' })
+    expect(categoryNav.textContent).toBe('Trend')
+    expect(categoryNav.textContent).not.toContain('Control')
+    expect(categoryNav.textContent).not.toContain('RTR')
+    expect(categoryNav.textContent).not.toContain('Resources')
+    expect(categoryNav.textContent).not.toContain('Alerts')
+    expect(categoryNav.textContent).not.toContain('Assistant')
+    expect(screen.getByRole('button', { name: 'INSIGHTS' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('step')
+  })
+
+  it('verify_src001_s0002_r006_a01 keeps settings as a header button instead of a subtab', async () => {
+    renderApp('/control')
+
+    expect(screen.getByRole('navigation', { name: 'Global navigation' }).textContent).not.toContain('Settings')
+    expect(screen.getByRole('navigation', { name: 'Category subtab navigation' }).textContent).not.toContain('Settings')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open settings' }))
+
+    expect(await screen.findByRole('heading', { name: 'Settings' })).toBeTruthy()
+    expect(screen.getByRole('navigation', { name: 'Global navigation' })).toBeTruthy()
+    expect(screen.queryByRole('navigation', { name: 'Category subtab navigation' })).toBeNull()
   })
 
   it('keeps control section actions inline and leaves the recommended control surface visible', async () => {
@@ -934,15 +1037,16 @@ describe('App routed shell', () => {
     expect(screen.getByText('AlertRail')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
     expect(screen.queryByTestId('page-section-active')).toBeNull()
-    expect(screen.getByRole('button', { name: 'Action:control-devices' }).getAttribute('aria-current')).toBe('step')
+    expect(screen.getByRole('button', { name: 'Action:control-devices' }).getAttribute('aria-pressed')).toBe('true')
 
     fireEvent.click(screen.getByRole('button', { name: 'Action:control-strategy' }))
 
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByText('AlertRail')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Action:control-strategy' }).getAttribute('aria-current')).toBe('step')
-    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Action:control-strategy' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('opens the assistant drawer from the topbar without leaving the current shell page', async () => {
@@ -954,7 +1058,8 @@ describe('App routed shell', () => {
 
     expect(await screen.findByText('AssistantDrawer:assistant-chat')).toBeTruthy()
     expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
-    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'INSIGHTS' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('opens the assistant drawer from the floating button on non-assistant routes', async () => {
@@ -980,7 +1085,8 @@ describe('App routed shell', () => {
 
     expect(await screen.findByText('AlertsCommandCenter:alerts-priority')).toBeTruthy()
     expect(screen.getByTestId('topbar-title').textContent).toBe('Alerts')
-    expect(screen.getByRole('button', { name: 'Alerts' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Alerts' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('keeps trend as a dedicated page separated from control', async () => {
@@ -989,7 +1095,8 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
     expect(await screen.findByText('WeatherOutlookPanel')).toBeTruthy()
     expect(await screen.findByText('DecisionSnapshotGrid')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'INSIGHTS' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('preserves /trend hook loading and error state plumbing when weather, produce, and overview signals are unavailable', async () => {
@@ -1020,7 +1127,8 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('topbar-title').textContent).toBe('Crop Work')
     expect(await screen.findByText('CropDetails')).toBeTruthy()
     expect(await screen.findByText('TodayBoard')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Crop Work' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Crop Work' }).getAttribute('aria-current')).toBe('step')
   })
 
   it.each([
@@ -1036,7 +1144,8 @@ describe('App routed shell', () => {
     expect(await screen.findByRole('heading', { name: 'Assistant' })).toBeTruthy()
     expect(await screen.findByText(expectedPanel)).toBeTruthy()
     expect(screen.queryByRole('heading', { name: 'Today operations' })).toBeNull()
-    expect(screen.getByRole('button', { name: 'Assistant' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'KNOWLEDGE' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Assistant' }).getAttribute('aria-current')).toBe('step')
   })
 
   it.each([
@@ -1067,7 +1176,8 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('advisor-initial-tab').textContent).toBe('nutrient')
     expect(screen.getByTestId('advisor-correction-open').textContent).toBe('false')
     expect(screen.queryByRole('heading', { name: 'Today operations' })).toBeNull()
-    expect(screen.getByRole('button', { name: 'Resources' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Resources' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('opens the harvest advisor lane through the live advisor tab surface', async () => {
@@ -1077,7 +1187,8 @@ describe('App routed shell', () => {
     expect(await screen.findByText('AdvisorTabs')).toBeTruthy()
     expect(screen.getByTestId('advisor-initial-tab').textContent).toBe('harvest_market')
     expect(screen.queryByRole('heading', { name: 'Today operations' })).toBeNull()
-    expect(screen.getByRole('button', { name: 'Crop Work' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Crop Work' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('keeps nested harvest advisor aliases on the live advisor tab surface', async () => {
@@ -1095,7 +1206,8 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('topbar-title').textContent).toBe('Alerts')
     expect(await screen.findByText('AdvisorTabs')).toBeTruthy()
     expect(screen.getByTestId('advisor-initial-tab').textContent).toBe('pesticide')
-    expect(screen.getByRole('button', { name: 'Alerts' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Alerts' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('keeps nested growth advisor aliases on the live advisor tab surface', async () => {
@@ -1130,7 +1242,8 @@ describe('App routed shell', () => {
     expect(await screen.findByText('AdvisorTabs')).toBeTruthy()
     expect(screen.getByTestId('advisor-initial-tab').textContent).toBe('nutrient')
     expect(screen.getByTestId('advisor-correction-open').textContent).toBe('true')
-    expect(screen.getByRole('button', { name: 'Resources' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Resources' }).getAttribute('aria-current')).toBe('step')
   })
 
   it('keeps assistant flows inline inside the assistant route', async () => {

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LocaleProvider } from './i18n/LocaleProvider'
 import { LOCALE_STORAGE_KEY } from './i18n/locale'
+import type { ModelRuntimeConstraintViolation } from './hooks/useSmartGrowAdvisor'
 import type { MetricHistoryPoint } from './types'
 import { deriveSourceSinkBalance } from './utils/derivedRuntimeMetrics'
 
@@ -127,7 +128,7 @@ const advisorState = {
     },
     recommendations: [{ action: 'Keep vent bias conservative.' }],
     constraint_checks: {
-      violated_constraints: [],
+      violated_constraints: [] as ModelRuntimeConstraintViolation[],
     },
     state_snapshot: {
       source_sink_balance: 0.42,
@@ -455,23 +456,39 @@ vi.mock('./components/dashboard/HeroControlCard', () => ({
     sourceSinkBalance,
     canopyAssimilation,
     lai,
+    importantIssue,
   }: {
     onOpenAdvisor?: () => void
     sourceSinkBalance?: number | null
     canopyAssimilation?: number | null
     lai?: number | null
+    importantIssue?: string | null
   }) => (
     <div>
       <div>HeroControlCard</div>
       <div data-testid="hero-source-sink">{String(sourceSinkBalance ?? '')}</div>
       <div data-testid="hero-canopy">{String(canopyAssimilation ?? '')}</div>
       <div data-testid="hero-lai">{String(lai ?? '')}</div>
+      <div data-testid="hero-important-issue">{importantIssue ?? ''}</div>
       <button type="button" onClick={onOpenAdvisor}>Open advisor lane</button>
     </div>
   ),
 }))
 vi.mock('./components/dashboard/LiveMetricStrip', () => ({ default: () => <div>LiveMetricStrip</div> }))
-vi.mock('./components/dashboard/AlertRail', () => ({ default: () => <div>AlertRail</div> }))
+vi.mock('./components/dashboard/AlertRail', () => ({
+  default: ({
+    items,
+  }: {
+    items?: Array<{ title: string; body: string; auxiliaryText?: string }>
+  }) => (
+    <div>
+      <div>AlertRail</div>
+      <div data-testid="alert-rail-items">
+        {(items ?? []).map((item) => `${item.title} ${item.body} ${item.auxiliaryText ?? ''}`).join(' | ')}
+      </div>
+    </div>
+  ),
+}))
 vi.mock('./components/dashboard/DecisionSnapshotGrid', () => ({
   default: ({
     weather,
@@ -691,8 +708,8 @@ vi.mock('./features/assistant/AssistantFab', () => ({
 
 import App from './App'
 
-function renderApp(initialPath = '/overview') {
-  window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+function renderApp(initialPath = '/overview', locale = 'en') {
+  window.localStorage.setItem(LOCALE_STORAGE_KEY, locale)
 
   render(
     <LocaleProvider>
@@ -1047,6 +1064,86 @@ describe('App routed shell', () => {
     expect(screen.getByRole('button', { name: 'Action:control-strategy' }).getAttribute('aria-pressed')).toBe('true')
     expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
+  })
+
+  it('renders runtime constraint alerts through friendly copy without raw identifiers', async () => {
+    const originalViolations = advisorState.aiModelRuntime.constraint_checks.violated_constraints
+    advisorState.aiModelRuntime.constraint_checks.violated_constraints = [{
+      code: 'humidity_floor_risk',
+      control: 'rh_target',
+      severity: 'high',
+      message: 'rh_target decrease triggers humidity_floor_risk below floor',
+    }, {
+      code: 'disease_risk_high',
+      control: 'rh_target',
+      severity: 'high',
+      message: 'Resulting RH exceeds the bounded disease-risk ceiling.',
+    }]
+
+    try {
+      renderApp('/control', 'ko')
+
+      expect(await screen.findByText('AlertRail')).toBeTruthy()
+      const alertText = screen.getByTestId('alert-rail-items').textContent ?? ''
+
+      expect(alertText).toContain('습도 회복 하한 위험')
+      expect(alertText).toContain('습도 목표를 낮추면 상대습도가 회복 하한 아래로 떨어질 수 있어요.')
+      expect(alertText).toContain('습도 병해 위험')
+      expect(alertText).not.toContain('rh_target')
+      expect(alertText).not.toContain('humidity_floor_risk')
+      expect(alertText).not.toContain('disease_risk_high')
+      expect(alertText).not.toContain('triggers')
+      expect(alertText).not.toContain('bounded disease-risk ceiling')
+    } finally {
+      advisorState.aiModelRuntime.constraint_checks.violated_constraints = originalViolations
+    }
+  })
+
+  it('keeps unknown runtime constraint codes in auxiliary alert text only', async () => {
+    const originalViolations = advisorState.aiModelRuntime.constraint_checks.violated_constraints
+    advisorState.aiModelRuntime.constraint_checks.violated_constraints = [{
+      code: 'custom_floor_risk',
+      control: 'unknown_control',
+      severity: 'high',
+      message: 'unknown_control triggered custom_floor_risk',
+    }]
+
+    try {
+      renderApp('/control', 'ko')
+
+      expect(await screen.findByText('AlertRail')).toBeTruthy()
+      const alertText = screen.getByTestId('alert-rail-items').textContent ?? ''
+
+      expect(alertText).toContain('운영 제약 확인 필요')
+      expect(alertText).toContain('사전에 없는 운영 제약이 감지되었습니다. 현재 설정을 확인해 주세요.')
+      expect(alertText).toContain('원문 코드: unknown_control · custom_floor_risk')
+    } finally {
+      advisorState.aiModelRuntime.constraint_checks.violated_constraints = originalViolations
+    }
+  })
+
+  it('uses friendly runtime constraint copy in the overview hero screen-reader issue text', async () => {
+    const originalViolations = advisorState.aiModelRuntime.constraint_checks.violated_constraints
+    const originalRisks = advisorState.aiDisplay.risks
+    advisorState.aiDisplay.risks = []
+    advisorState.aiModelRuntime.constraint_checks.violated_constraints = [{
+      code: 'humidity_floor_risk',
+      control: 'rh_target',
+      severity: 'medium',
+      message: 'Resulting RH falls below the bounded recovery floor.',
+    }]
+
+    try {
+      renderApp('/overview', 'ko')
+
+      const heroIssue = await screen.findByTestId('hero-important-issue')
+      expect(heroIssue.textContent).toBe('습도 목표를 낮추면 상대습도가 회복 하한 아래로 떨어질 수 있어요. 현재 설정을 확인해 주세요.')
+      expect(heroIssue.textContent).not.toContain('humidity_floor_risk')
+      expect(heroIssue.textContent).not.toContain('bounded recovery floor')
+    } finally {
+      advisorState.aiDisplay.risks = originalRisks
+      advisorState.aiModelRuntime.constraint_checks.violated_constraints = originalViolations
+    }
   })
 
   it('opens the assistant drawer from the topbar without leaving the current shell page', async () => {

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -1362,12 +1362,14 @@ describe('App routed shell', () => {
     expect(screen.getByTestId('decision-snapshot-props').textContent).toContain('overview:null')
   })
 
-  it('keeps crop-work as a dedicated page instead of assembling it inline in App', async () => {
+  it('keeps crop-work as a dedicated page and dedups TodayBoard to its canonical HOME Watch tab', async () => {
     renderApp('/crop-work')
 
     expect(screen.getByTestId('topbar-title').textContent).toBe('Crop Work')
     expect(await screen.findByText('CropDetails')).toBeTruthy()
-    expect(await screen.findByText('TodayBoard')).toBeTruthy()
+    // R19 dedup: TodayBoard's canonical home is the HOME Watch tab only, so it no longer
+    // renders on /crop-work (its data survives on HOME Watch — WatchTab.prd004.test.tsx).
+    expect(screen.queryByText('TodayBoard')).toBeNull()
     expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('button', { name: 'Crop Work' }).getAttribute('aria-current')).toBe('step')
   })

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -1256,6 +1256,40 @@ describe('App routed shell', () => {
     expect(bodyText.indexOf('ControlPanel')).toBeLessThan(bodyText.indexOf('AlertRail'))
   })
 
+  it('verify_src001_s0005_r001_a01 keeps /rtr limited to the RTR optimizer surface', async () => {
+    renderApp('/rtr')
+
+    expect(screen.getByTestId('topbar-title').textContent).toBe('RTR Optimizer')
+    expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
+    expect(screen.queryByText('ControlPanel')).toBeNull()
+    expect(screen.queryByText('DecisionSnapshotGrid')).toBeNull()
+    expect(screen.getByRole('button', { name: 'RTR Optimizer' }).getAttribute('aria-current')).toBe('step')
+  })
+
+  it('verify_src001_s0005_r002_a01 keeps removed panels reachable from their canonical tabs', async () => {
+    renderApp('/rtr')
+
+    expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
+    expect(screen.queryByText('ControlPanel')).toBeNull()
+    expect(screen.queryByText('DecisionSnapshotGrid')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Control' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topbar-title').textContent).toBe('Control Solutions')
+    })
+    expect(await screen.findByText('ControlPanel')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
+
+    fireEvent.click(screen.getByRole('button', { name: 'INSIGHTS' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topbar-title').textContent).toBe('Trend')
+    })
+    expect(await screen.findByText('DecisionSnapshotGrid')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Trend' }).getAttribute('aria-current')).toBe('step')
+  })
+
   it('opens the assistant drawer from the topbar without leaving the current shell page', async () => {
     renderApp('/trend')
 

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from 'react'
 import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LocaleProvider } from './i18n/LocaleProvider'
 import { LOCALE_STORAGE_KEY } from './i18n/locale'
 import type { ModelRuntimeConstraintViolation } from './hooks/useSmartGrowAdvisor'
@@ -720,6 +720,47 @@ function renderApp(initialPath = '/overview', locale = 'en') {
   )
 }
 
+function jsonResponse(payload: Record<string, unknown>, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => payload,
+  } as Response
+}
+
+function stubSettingsAndRuntimeFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+
+    if (url.includes('/settings')) {
+      return jsonResponse({
+        settings: {
+          price_per_kg: 3200,
+          cost_per_kwh: 125,
+        },
+      })
+    }
+
+    if (url.includes('/speed')) {
+      return jsonResponse({ status: 'speed-ok', body: init?.body ?? null })
+    }
+
+    if (url.includes('/pause')) {
+      return jsonResponse({ status: 'pause-ok' })
+    }
+
+    if (url.includes('/resume')) {
+      return jsonResponse({ status: 'resume-ok' })
+    }
+
+    return jsonResponse({ status: 'success' })
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
 describe('App routed shell', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -769,6 +810,10 @@ describe('App routed shell', () => {
     }
     overviewSignalsState.loading = false
     overviewSignalsState.error = null
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('renders the direct route entry without falling back to the giant overview stack', async () => {
@@ -1144,6 +1189,71 @@ describe('App routed shell', () => {
       advisorState.aiDisplay.risks = originalRisks
       advisorState.aiModelRuntime.constraint_checks.violated_constraints = originalViolations
     }
+  })
+
+  it('verify_src001_s0004_r001_a01 moves SimulationRuntimePanel from /control to /settings', async () => {
+    stubSettingsAndRuntimeFetch()
+
+    renderApp('/control')
+
+    expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Live Climate & Controls' })).toBeNull()
+    expect(screen.queryByText('Simulation Runtime')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open settings' }))
+
+    expect(await screen.findByRole('heading', { name: 'Settings' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: 'Live Climate & Controls' })).toBeTruthy()
+    expect(screen.getByText('Simulation Runtime')).toBeTruthy()
+  })
+
+  it('verify_src001_s0004_r002_a01 keeps settings runtime pace presets, pause/resume, and sg-sim-pace persistence working', async () => {
+    const fetchMock = stubSettingsAndRuntimeFetch()
+    window.localStorage.setItem('sg-sim-pace', '60')
+
+    renderApp('/settings')
+
+    expect(await screen.findByRole('heading', { name: 'Live Climate & Controls' })).toBeTruthy()
+
+    for (const label of ['10 s/s', '20 s/s', '30 s/s', '60 s/s', '600 s/s', '6000 s/s']) {
+      expect(screen.getByRole('button', { name: label })).toBeTruthy()
+    }
+    expect(screen.getByRole('button', { name: '60 s/s' }).getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: '6000 s/s' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '6000 s/s' }).getAttribute('aria-pressed')).toBe('true')
+    })
+
+    const speedCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/speed'))
+    expect(speedCall).toBeTruthy()
+    const speedBody = JSON.parse((speedCall?.[1]?.body as string) ?? '{}')
+    expect(speedBody.sim_seconds_per_real_second).toBe(6000)
+    expect(window.localStorage.getItem('sg-sim-pace')).toBe('6000')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }))
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/pause'))).toBe(true)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume' }))
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/resume'))).toBe(true)
+    })
+  })
+
+  it('verify_src001_s0004_r003_a01 starts /control with operator control content instead of runtime controls', async () => {
+    renderApp('/control')
+
+    expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
+    expect(screen.getByText('ControlPanel')).toBeTruthy()
+    expect(screen.getByText('AlertRail')).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Live Climate & Controls' })).toBeNull()
+
+    const bodyText = document.body.textContent ?? ''
+    expect(bodyText.indexOf('RTROptimizerPanel')).toBeLessThan(bodyText.indexOf('ControlPanel'))
+    expect(bodyText.indexOf('ControlPanel')).toBeLessThan(bodyText.indexOf('AlertRail'))
   })
 
   it('opens the assistant drawer from the topbar without leaving the current shell page', async () => {

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -838,7 +838,7 @@ describe('App routed shell', () => {
 
     try {
       renderApp('/overview')
-      await waitForElementToBeRemoved(() => screen.queryByText('화면을 불러오는 중입니다.'), { timeout: 5000 })
+      await waitForElementToBeRemoved(() => screen.queryByText('화면을 불러오는 중입니다.'), { timeout: 15000 })
 
       const expectedSourceSinkBalance = deriveSourceSinkBalance({
         crop: 'Cucumber',
@@ -846,14 +846,14 @@ describe('App routed shell', () => {
         metrics: greenhouseState.modelMetrics as Parameters<typeof deriveSourceSinkBalance>[0]['metrics'],
       })
 
-      expect(await screen.findByTestId('hero-source-sink', {}, { timeout: 5000 })).toBeTruthy()
+      expect(await screen.findByTestId('hero-source-sink', {}, { timeout: 15000 })).toBeTruthy()
       expect(screen.getByTestId('hero-source-sink').textContent).toBe(String(expectedSourceSinkBalance))
       expect(screen.getByTestId('hero-canopy').textContent).toBe(String(greenhouseState.currentData.photosynthesis))
       expect(screen.getByTestId('hero-lai').textContent).toBe(String(greenhouseState.modelMetrics.growth.lai))
     } finally {
       advisorState.aiModelRuntime.state_snapshot = originalSnapshot
     }
-  })
+  }, 20000)
 
   it('uses simulation timestamps for the live source-sink overlay series', async () => {
     const originalMetricHistory = greenhouseState.metricHistory
@@ -1086,26 +1086,26 @@ describe('App routed shell', () => {
     expect(screen.queryByRole('navigation', { name: 'Category subtab navigation' })).toBeNull()
   })
 
-  it('keeps control section actions inline and leaves the recommended control surface visible', async () => {
+  it('verify_src001_s0006_r002_a01 keeps AlertRail off /control while leaving the control surfaces visible', async () => {
     renderApp('/control')
 
-    expect(screen.getByText('AlertRail')).toBeTruthy()
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
+    expect(screen.queryByText('AlertRail')).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Action:control-devices' }))
 
     expect(screen.queryByText('RTROptimizerPanel')).toBeNull()
-    expect(screen.getByText('AlertRail')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
+    expect(screen.queryByText('AlertRail')).toBeNull()
     expect(screen.queryByTestId('page-section-active')).toBeNull()
     expect(screen.getByRole('button', { name: 'Action:control-devices' }).getAttribute('aria-pressed')).toBe('true')
 
     fireEvent.click(screen.getByRole('button', { name: 'Action:control-strategy' }))
 
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
-    expect(screen.getByText('AlertRail')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
+    expect(screen.queryByText('AlertRail')).toBeNull()
     expect(screen.getByRole('button', { name: 'Action:control-strategy' }).getAttribute('aria-pressed')).toBe('true')
     expect(screen.getByRole('button', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step')
@@ -1126,7 +1126,7 @@ describe('App routed shell', () => {
     }]
 
     try {
-      renderApp('/control', 'ko')
+      renderApp('/overview#overview-watch', 'ko')
 
       expect(await screen.findByText('AlertRail')).toBeTruthy()
       const alertText = screen.getByTestId('alert-rail-items').textContent ?? ''
@@ -1154,7 +1154,7 @@ describe('App routed shell', () => {
     }]
 
     try {
-      renderApp('/control', 'ko')
+      renderApp('/overview#overview-watch', 'ko')
 
       expect(await screen.findByText('AlertRail')).toBeTruthy()
       const alertText = screen.getByTestId('alert-rail-items').textContent ?? ''
@@ -1248,12 +1248,11 @@ describe('App routed shell', () => {
 
     expect(await screen.findByText('RTROptimizerPanel')).toBeTruthy()
     expect(screen.getByText('ControlPanel')).toBeTruthy()
-    expect(screen.getByText('AlertRail')).toBeTruthy()
+    expect(screen.queryByText('AlertRail')).toBeNull()
     expect(screen.queryByRole('heading', { name: 'Live Climate & Controls' })).toBeNull()
 
     const bodyText = document.body.textContent ?? ''
     expect(bodyText.indexOf('RTROptimizerPanel')).toBeLessThan(bodyText.indexOf('ControlPanel'))
-    expect(bodyText.indexOf('ControlPanel')).toBeLessThan(bodyText.indexOf('AlertRail'))
   })
 
   it('verify_src001_s0005_r001_a01 keeps /rtr limited to the RTR optimizer surface', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1455,12 +1455,6 @@ function App() {
       optimizerEnabled={optimizerEnabled}
       defaultMode={selectedRtrProfile?.optimizer?.default_mode}
       onRefreshProfiles={refreshRtrProfiles}
-      controls={controls}
-      onToggle={toggleControl}
-      onSettingsChange={setTempSettings}
-      modelMetrics={deferredModelMetrics}
-      producePrices={producePrices}
-      produceLoading={isProducePricesLoading}
       optimizerState={rtrOptimizerState}
       uiState={rtrOptimizerUiState}
     />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1520,6 +1520,8 @@ function App() {
       selectedCropLabel={selectedCropLabel}
       assistantOpen={assistantDrawerOpen}
       telemetrySummary={kpiStatusSummary}
+      telemetryStatus={telemetry.status}
+      telemetryDetail={telemetryDetail}
       weatherConnected={Boolean(weather)}
       marketConnected={Boolean(producePrices)}
     />
@@ -1666,8 +1668,6 @@ function App() {
                   ? 'control-devices'
                   : 'control-strategy'}
                 crop={selectedCrop}
-                telemetryStatus={telemetry.status}
-                telemetryDetail={telemetryDetail}
                 controls={controls}
                 onToggle={toggleControl}
                 onSettingsChange={setTempSettings}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import {
 import {
   getCropLabel,
   getDashboardSensorCopy,
+  getRuntimeConstraintDisplayCopy,
   NUMERIC_IDEAL_RANGES,
 } from './utils/displayCopy';
 import {
@@ -1146,8 +1147,11 @@ function App() {
     ?? smartGrowHeroSummary
     ?? heroCopy.fallbackSummary;
 
+  const runtimeImportantIssue = runtimeViolations[0]
+    ? getRuntimeConstraintDisplayCopy(runtimeViolations[0], locale).body
+    : null;
   const heroImportantIssue = aiDisplay?.risks?.[0]
-    ?? runtimeViolations[0]?.message
+    ?? runtimeImportantIssue
     ?? (telemetry.status === 'offline' ? heroCopy.telemetryOffline : null)
     ?? ((telemetry.status === 'stale' || telemetry.status === 'delayed') ? heroCopy.telemetryStale : null);
 
@@ -1280,12 +1284,16 @@ function App() {
             body: heroCopy.telemetryStale,
           }]
         : []),
-    ...runtimeViolations.slice(0, 2).map((violation, index) => ({
-      id: `runtime-${violation.code ?? index}`,
-      severity: violation.severity === 'critical' ? 'critical' as const : 'warning' as const,
-      title: violation.control ? `${violation.control} · ${violation.code}` : violation.code,
-      body: violation.message,
-    })),
+    ...runtimeViolations.slice(0, 2).map((violation, index) => {
+      const constraintCopy = getRuntimeConstraintDisplayCopy(violation, locale);
+      return {
+        id: `runtime-${violation.code ?? index}`,
+        severity: violation.severity === 'critical' ? 'critical' as const : 'warning' as const,
+        title: constraintCopy.title,
+        body: constraintCopy.body,
+        auxiliaryText: constraintCopy.auxiliaryText,
+      };
+    }),
     ...(aiDisplay?.risks ?? []).slice(0, 2).map((risk, index) => ({
       id: `risk-${index}`,
       severity: 'warning' as const,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1660,8 +1660,6 @@ function App() {
                 controls={controls}
                 onToggle={toggleControl}
                 onSettingsChange={setTempSettings}
-                alertItems={alertItems}
-                fallbackAlertBody={heroCopy.telemetryLive}
                 history={deferredHistory}
                 currentData={currentData}
                 weather={weather}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1309,12 +1309,7 @@ function App() {
       modelMetrics={deferredModelMetrics}
       forecast={deferredForecast}
       aiAnalysis={aiAnalysis}
-      actionsNow={aiDisplay?.actions_now ?? []}
-      actionsToday={aiDisplay?.actions_today ?? []}
-      actionsWeek={aiDisplay?.actions_week ?? []}
-      monitor={aiDisplay?.monitor ?? []}
       activePanel={activePanelId === 'crop-work-harvest' ? 'crop-work-harvest' : activePanelId === 'crop-work-work' ? 'crop-work-work' : 'crop-work-growth'}
-      onOpenAssistant={() => openAssistantDrawer('assistant-chat')}
     />
   );
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,11 @@ import {
   getSectionPathForAdvisorTab,
 } from './routes/phytosyncSections';
 import {
+  GLOBAL_NAVIGATION_ITEMS,
+  getGlobalNavigationKeyForPathname,
+  getSubNavigationSectionKeys,
+} from './routes/globalNavigation';
+import {
   getCropLabel,
   getDashboardSensorCopy,
   NUMERIC_IDEAL_RANGES,
@@ -382,6 +387,10 @@ function App() {
   const deferredModelMetrics = useDeferredValue(modelMetrics);
   const primaryRoutes = useMemo(() => buildPrimaryRoutes(locale), [locale]);
   const activePrimaryRouteKey = useMemo(() => getPrimaryRouteKey(location.pathname), [location.pathname]);
+  const activeGlobalNavigationKey = useMemo(
+    () => getGlobalNavigationKeyForPathname(location.pathname),
+    [location.pathname],
+  );
   const activePrimaryRoute = useMemo(
     () => getPrimaryRouteMeta(location.pathname, locale),
     [location.pathname, locale],
@@ -844,6 +853,19 @@ function App() {
     navigate('/settings');
   }, [navigate, setAssistantDrawerOpen]);
 
+  const handleGlobalNavigationSelect = useCallback(() => {
+    setAssistantDrawerOpen(false);
+  }, [setAssistantDrawerOpen]);
+
+  const handleGlobalContactSelect = useCallback(() => {
+    setAssistantDrawerOpen(false);
+    if (location.pathname === '/overview') {
+      document.getElementById('overview-footer')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      return;
+    }
+    navigate({ pathname: '/overview', hash: '#contact' });
+  }, [location.pathname, navigate, setAssistantDrawerOpen]);
+
   const handleOpenAlerts = useCallback(() => {
     setAssistantDrawerOpen(false);
     navigate({ pathname: '/alerts', hash: '#alerts-priority' });
@@ -1066,16 +1088,28 @@ function App() {
     weather,
   ]);
 
-  const workspaceItems = useMemo<WorkspaceNavItem[]>(() => (
-    primaryRoutes.map((route) => ({
-      key: route.key,
-      label: route.label,
-      shortLabel: route.shortLabel,
-      description: route.description,
-      icon: route.icon,
-      actions: sections.find((section) => section.key === route.key)?.tabs ?? [],
-    }))
-  ), [primaryRoutes, sections]);
+  const workspaceItems = useMemo<WorkspaceNavItem[]>(() => {
+    const visibleSectionKeys = getSubNavigationSectionKeys(activeGlobalNavigationKey);
+    const nextItems: WorkspaceNavItem[] = [];
+
+    for (const sectionKey of visibleSectionKeys) {
+      const section = sections.find((candidate) => candidate.key === sectionKey);
+      if (!section) {
+        continue;
+      }
+
+      nextItems.push({
+        key: section.key,
+        label: section.label,
+        shortLabel: section.shortLabel,
+        description: section.description,
+        icon: section.icon,
+        actions: section.tabs,
+      });
+    }
+
+    return nextItems;
+  }, [activeGlobalNavigationKey, sections]);
 
   const heroPrimaryNarrative = runtimeRecommendedAction
     ? (locale === 'ko' ? `지금: ${runtimeRecommendedAction}` : `Now: ${runtimeRecommendedAction}`)
@@ -1598,9 +1632,13 @@ function App() {
       )}
     >
       <WorkspaceTopNav
+        globalItems={GLOBAL_NAVIGATION_ITEMS}
         items={workspaceItems}
+        activeGlobalKey={activeGlobalNavigationKey}
         activeWorkspace={activePrimaryRouteKey}
         activeActionId={activePanelId}
+        onSelectGlobal={handleGlobalNavigationSelect}
+        onSelectContact={handleGlobalContactSelect}
         onSelect={handleWorkspaceSelect}
         onSelectAction={handleWorkspaceActionSelect}
       />

--- a/frontend/src/app/operation-compatibility.contract.test.ts
+++ b/frontend/src/app/operation-compatibility.contract.test.ts
@@ -6,6 +6,7 @@ import {
   BACKEND_INTEGRATION_INVENTORY,
   REQUIRED_BACKEND_ENDPOINTS,
 } from './backend-integration-inventory';
+import { COMMAND_DESIGN_PARITY_CONTRACT } from './commandDesignParity';
 import { buildPrimaryRoutes, getPrimaryRouteKey } from './route-meta';
 import {
   buildPhytoSections,
@@ -129,6 +130,17 @@ const EXPECTED_PRIMARY_ROUTE_CONTRACTS = [
   { key: 'settings', path: '/settings' },
 ] as const;
 
+const REQUIRED_REPOSITORY_IGNORE_PATTERNS = [
+  'docs/',
+  'screenshots/',
+  '*.screenshot.png',
+  '*.screenshot.jpg',
+  '*.screenshot.jpeg',
+  '.rah/',
+] as const;
+
+const R27_PHASE_FILE_LIMIT = 5;
+
 function runGit(args: string[]): string {
   return execFileSync('git', args, {
     cwd: REPO_ROOT,
@@ -140,89 +152,303 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function splitGitLines(value: string): string[] {
+  return value ? value.split('\n').filter(Boolean) : [];
+}
+
+function isRepositoryArtifactPath(value: string): boolean {
+  return (
+    value.startsWith('docs/')
+    || value.startsWith('screenshots/')
+    || value.startsWith('.rah/')
+    || /\.(?:screenshot\.(?:png|jpe?g))$/i.test(value)
+  );
+}
+
+function assertNoBackendHookOrRouteDrift({
+  requiredEndpoints,
+  connectedEndpoints,
+  routeContracts,
+  inventory,
+}: {
+  requiredEndpoints: readonly string[];
+  connectedEndpoints: readonly string[];
+  routeContracts: readonly { key: string; path: string }[];
+  inventory: readonly { frontend: string; route: string }[];
+}) {
+  expect([...requiredEndpoints]).toEqual([...EXPECTED_REQUIRED_BACKEND_ENDPOINTS]);
+  expect(connectedEndpoints).toEqual([...EXPECTED_CONNECTED_BACKEND_ENDPOINTS]);
+  expect(routeContracts).toEqual([...EXPECTED_PRIMARY_ROUTE_CONTRACTS]);
+  expect(inventory.every((entry) => Boolean(entry.frontend.trim() && entry.route.trim()))).toBe(true);
+}
+
+function assertNoPacingNavTrendOrCommandParityRegression({
+  pacePresets,
+  defaultPace,
+  cucumberPaceRequest,
+  tomatoDefaultPaceRequest,
+  trendRoute,
+  trendRouteKey,
+  nestedTrendRouteKey,
+  trendSectionKey,
+  nestedTrendSectionKey,
+  defaultTrendPath,
+  commandParity,
+}: {
+  pacePresets: readonly number[];
+  defaultPace: number;
+  cucumberPaceRequest: { path: string; init: RequestInit };
+  tomatoDefaultPaceRequest: { path: string; init: RequestInit };
+  trendRoute: { key?: string; path?: string; label?: string; visibleInNav?: boolean } | undefined;
+  trendRouteKey: string;
+  nestedTrendRouteKey: string;
+  trendSectionKey: string;
+  nestedTrendSectionKey: string;
+  defaultTrendPath: string;
+  commandParity: {
+    issueId: string;
+    paritySurfaces: readonly {
+      path?: string;
+      tab?: string;
+      panel?: string;
+      marker: string;
+    }[];
+    designLanguage: {
+      requiredClasses: readonly string[];
+      sharedComponents: readonly string[];
+      statusChipTones: readonly string[];
+    };
+  };
+}) {
+  expect(pacePresets).toEqual([10, 20, 30, 60, 600, 6000]);
+  expect(defaultPace).toBe(600);
+  expect(cucumberPaceRequest.path).toBe('/speed?crop=cucumber');
+  expect(cucumberPaceRequest.init.method).toBe('POST');
+  expect(cucumberPaceRequest.init.headers).toEqual({ 'Content-Type': 'application/json' });
+  expect(JSON.parse(String(cucumberPaceRequest.init.body))).toEqual({
+    sim_seconds_per_real_second: 6000,
+    speed: 1,
+  });
+  expect(tomatoDefaultPaceRequest.path).toBe('/speed?crop=tomato');
+  expect(JSON.parse(String(tomatoDefaultPaceRequest.init.body))).toEqual({
+    sim_seconds_per_real_second: 600,
+    speed: 0.1,
+  });
+
+  expect(trendRoute).toMatchObject({
+    key: 'trend',
+    path: '/trend',
+    label: 'Trend',
+    visibleInNav: true,
+  });
+  expect(trendRouteKey).toBe('trend');
+  expect(nestedTrendRouteKey).toBe('trend');
+  expect(trendSectionKey).toBe('trend');
+  expect(nestedTrendSectionKey).toBe('trend');
+  expect(defaultTrendPath).toBe('/trend');
+
+  expect(commandParity.issueId).toBe('#133');
+  expect(commandParity.paritySurfaces).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ path: '/overview', tab: 'Dashboard', marker: 'overview-dashboard' }),
+      expect.objectContaining({ path: '/overview', tab: 'Watch', marker: 'overview-watch' }),
+      expect.objectContaining({ path: '/trend', panel: 'WeatherTrendPanel', marker: 'trend-weather' }),
+      expect.objectContaining({ path: '/trend', panel: 'WeatherOutlookPanel', marker: 'trend-weather' }),
+      expect.objectContaining({ path: '/trend', panel: 'ProducePricesPanel', marker: 'trend-market' }),
+      expect.objectContaining({ path: '/trend', panel: 'DecisionSnapshotGrid', marker: 'trend-decision' }),
+    ]),
+  );
+  expect(commandParity.designLanguage.requiredClasses).toEqual(['sg-data-number', 'sg-eyebrow']);
+  expect(commandParity.designLanguage.sharedComponents).toEqual([
+    'DashboardCard',
+    'MetricCard',
+    'SectionHeader',
+    'StatusChip',
+  ]);
+  expect(commandParity.designLanguage.statusChipTones).toEqual([
+    'growth',
+    'stable',
+    'warning',
+    'critical',
+    'muted',
+  ]);
+}
+
+function assertRepositoryPhaseContract({
+  gitignore,
+  ignoredPaths,
+  trackedRepositoryArtifacts,
+  changedFiles,
+}: {
+  gitignore: string;
+  ignoredPaths: readonly { path: string; ignoredAs: string }[];
+  trackedRepositoryArtifacts: readonly string[];
+  changedFiles: readonly string[];
+}) {
+  for (const pattern of REQUIRED_REPOSITORY_IGNORE_PATTERNS) {
+    expect(gitignore).toMatch(new RegExp(`^${escapeRegExp(pattern)}$`, 'm'));
+  }
+
+  for (const { path, ignoredAs } of ignoredPaths) {
+    expect(ignoredAs).toBe(path);
+  }
+
+  expect(trackedRepositoryArtifacts).toEqual([]);
+  expect(changedFiles.length).toBeLessThanOrEqual(R27_PHASE_FILE_LIMIT);
+  expect(changedFiles.filter(isRepositoryArtifactPath)).toEqual([]);
+}
+
 describe('PRD-008 operation compatibility contracts', () => {
   it('verify_src001_s0008_r001_a01 keeps backend APIs, data hook surfaces, and route paths unchanged', () => {
-    expect([...REQUIRED_BACKEND_ENDPOINTS]).toEqual([...EXPECTED_REQUIRED_BACKEND_ENDPOINTS]);
-    expect(BACKEND_INTEGRATION_INVENTORY.map(({ endpoint, status }) => ({ endpoint, status }))).toEqual(
-      EXPECTED_CONNECTED_BACKEND_ENDPOINTS.map((endpoint) => ({ endpoint, status: 'connected' })),
-    );
-    expect(BACKEND_INTEGRATION_INVENTORY.every((entry) => Boolean(entry.frontend.trim() && entry.route.trim()))).toBe(true);
-
     const enRoutes = buildPrimaryRoutes('en').map(({ key, path }) => ({ key, path }));
     const koRoutes = buildPrimaryRoutes('ko').map(({ key, path }) => ({ key, path }));
 
-    expect(enRoutes).toEqual([...EXPECTED_PRIMARY_ROUTE_CONTRACTS]);
-    expect(koRoutes).toEqual([...EXPECTED_PRIMARY_ROUTE_CONTRACTS]);
+    const contract = {
+      requiredEndpoints: REQUIRED_BACKEND_ENDPOINTS,
+      connectedEndpoints: BACKEND_INTEGRATION_INVENTORY.map(({ endpoint }) => endpoint),
+      routeContracts: enRoutes,
+      inventory: BACKEND_INTEGRATION_INVENTORY,
+    };
+
+    assertNoBackendHookOrRouteDrift(contract);
+    assertNoBackendHookOrRouteDrift({ ...contract, routeContracts: koRoutes });
+
+    expect(() => assertNoBackendHookOrRouteDrift({
+      ...contract,
+      requiredEndpoints: REQUIRED_BACKEND_ENDPOINTS.filter((endpoint) => endpoint !== '/api/status'),
+    })).toThrow();
+    expect(() => assertNoBackendHookOrRouteDrift({
+      ...contract,
+      connectedEndpoints: BACKEND_INTEGRATION_INVENTORY
+        .map(({ endpoint }) => endpoint)
+        .filter((endpoint) => endpoint !== '/api/weather/daegu'),
+    })).toThrow();
+    expect(() => assertNoBackendHookOrRouteDrift({
+      ...contract,
+      routeContracts: enRoutes.map((route) => route.key === 'trend'
+        ? { ...route, path: '/weather' }
+        : route),
+    })).toThrow();
+    expect(() => assertNoBackendHookOrRouteDrift({
+      ...contract,
+      inventory: BACKEND_INTEGRATION_INVENTORY.map((entry, index) => index === 0
+        ? { ...entry, frontend: '' }
+        : entry),
+    })).toThrow();
   });
 
-  it('verify_src001_s0008_r002_a01 keeps docs and screenshots ignored rather than tracked', () => {
+  it('verify_src001_s0008_r002_a01 preserves issue #131 pacing, issue #132 nav/trend, and issue #133 Command parity', () => {
+    const cucumberPaceRequest = buildSimulationPaceRequest('Cucumber', 6000);
+    const tomatoDefaultPaceRequest = buildSimulationPaceRequest('Tomato', DEFAULT_SIMULATION_PACE);
+    const sections = buildPhytoSections('en');
+    const trendRoute = buildPrimaryRoutes('en').find((route) => route.key === 'trend');
+
+    const contract = {
+      pacePresets: simulationRuntimePacePresets,
+      defaultPace: DEFAULT_SIMULATION_PACE,
+      cucumberPaceRequest,
+      tomatoDefaultPaceRequest,
+      trendRoute,
+      trendRouteKey: getPrimaryRouteKey('/trend'),
+      nestedTrendRouteKey: getPrimaryRouteKey('/trend/legacy'),
+      trendSectionKey: findPhytoSection(sections, '/trend').key,
+      nestedTrendSectionKey: findPhytoSection(sections, '/trend/legacy').key,
+      defaultTrendPath: getDefaultSectionPathForWorkspace('trend'),
+      commandParity: COMMAND_DESIGN_PARITY_CONTRACT,
+    };
+
+    assertNoPacingNavTrendOrCommandParityRegression(contract);
+
+    expect(() => assertNoPacingNavTrendOrCommandParityRegression({
+      ...contract,
+      pacePresets: [10, 20, 30, 60, 600],
+    })).toThrow();
+    expect(() => assertNoPacingNavTrendOrCommandParityRegression({
+      ...contract,
+      trendRoute: { ...trendRoute, path: '/weather' },
+    })).toThrow();
+    expect(() => assertNoPacingNavTrendOrCommandParityRegression({
+      ...contract,
+      defaultTrendPath: '/overview',
+    })).toThrow();
+    expect(() => assertNoPacingNavTrendOrCommandParityRegression({
+      ...contract,
+      commandParity: {
+        ...COMMAND_DESIGN_PARITY_CONTRACT,
+        paritySurfaces: COMMAND_DESIGN_PARITY_CONTRACT.paritySurfaces.filter(
+          (surface) => !('path' in surface && surface.path === '/trend'),
+        ),
+      },
+    })).toThrow();
+    expect(() => assertNoPacingNavTrendOrCommandParityRegression({
+      ...contract,
+      commandParity: {
+        ...COMMAND_DESIGN_PARITY_CONTRACT,
+        designLanguage: {
+          ...COMMAND_DESIGN_PARITY_CONTRACT.designLanguage,
+          requiredClasses: ['sg-eyebrow'],
+        },
+      },
+    })).toThrow();
+  });
+
+  it('verify_src001_s0008_r003_a01 keeps each phase within five files and excludes docs, screenshots, and .rah artifacts', () => {
     const gitignore = readFileSync(join(REPO_ROOT, '.gitignore'), 'utf8');
-
-    for (const pattern of [
-      'docs/',
-      'screenshots/',
-      '*.screenshot.png',
-      '*.screenshot.jpg',
-      '*.screenshot.jpeg',
-    ]) {
-      expect(gitignore).toMatch(new RegExp(`^${escapeRegExp(pattern)}$`, 'm'));
-    }
-
-    for (const ignoredPath of [
+    const ignoredPaths = [
       'docs/prd-008.md',
       'screenshots/prd-008.png',
+      '.rah/prd-008/state.json',
       'artifacts/prd-008/report.json',
       'out/prd-008/smoke.log',
       'runs-prd-008/output.log',
       'frontend/src/app/prd-008.screenshot.png',
-    ]) {
-      expect(runGit(['check-ignore', ignoredPath])).toBe(ignoredPath);
-    }
-
-    expect(runGit([
+    ].map((ignoredPath) => ({
+      path: ignoredPath,
+      ignoredAs: runGit(['check-ignore', ignoredPath]),
+    }));
+    const trackedRepositoryArtifacts = splitGitLines(runGit([
       'ls-files',
       '--',
       'docs',
       'screenshots',
+      '.rah',
       '*.screenshot.png',
       '*.screenshot.jpg',
       '*.screenshot.jpeg',
-    ])).toBe('');
-  });
+    ]));
+    const changedFiles = splitGitLines(runGit(['diff', '--name-only', 'HEAD', '--']));
 
-  it('verify_src001_s0008_r003_a01 preserves issue #131 pacing controls and issue #132 /trend routing', () => {
-    expect(simulationRuntimePacePresets).toEqual([10, 20, 30, 60, 600, 6000]);
-    expect(DEFAULT_SIMULATION_PACE).toBe(600);
+    const contract = {
+      gitignore,
+      ignoredPaths,
+      trackedRepositoryArtifacts,
+      changedFiles,
+    };
 
-    const cucumberPaceRequest = buildSimulationPaceRequest('Cucumber', 6000);
-    expect(cucumberPaceRequest.path).toBe('/speed?crop=cucumber');
-    expect(cucumberPaceRequest.init.method).toBe('POST');
-    expect(cucumberPaceRequest.init.headers).toEqual({ 'Content-Type': 'application/json' });
-    expect(JSON.parse(String(cucumberPaceRequest.init.body))).toEqual({
-      sim_seconds_per_real_second: 6000,
-      speed: 1,
-    });
+    assertRepositoryPhaseContract(contract);
 
-    const tomatoDefaultPaceRequest = buildSimulationPaceRequest('Tomato', DEFAULT_SIMULATION_PACE);
-    expect(tomatoDefaultPaceRequest.path).toBe('/speed?crop=tomato');
-    expect(JSON.parse(String(tomatoDefaultPaceRequest.init.body))).toEqual({
-      sim_seconds_per_real_second: 600,
-      speed: 0.1,
-    });
-
-    const sections = buildPhytoSections('en');
-    const trendRoute = buildPrimaryRoutes('en').find((route) => route.key === 'trend');
-
-    expect(trendRoute).toMatchObject({
-      key: 'trend',
-      path: '/trend',
-      label: 'Trend',
-      visibleInNav: true,
-    });
-    expect(getPrimaryRouteKey('/trend')).toBe('trend');
-    expect(getPrimaryRouteKey('/trend/legacy')).toBe('trend');
-    expect(findPhytoSection(sections, '/trend').key).toBe('trend');
-    expect(findPhytoSection(sections, '/trend/legacy').key).toBe('trend');
-    expect(getDefaultSectionPathForWorkspace('trend')).toBe('/trend');
+    expect(() => assertRepositoryPhaseContract({
+      ...contract,
+      gitignore: gitignore.replace(/^\.rah\/\r?\n/m, ''),
+    })).toThrow();
+    expect(() => assertRepositoryPhaseContract({
+      ...contract,
+      trackedRepositoryArtifacts: ['docs/prd-008.md'],
+    })).toThrow();
+    expect(() => assertRepositoryPhaseContract({
+      ...contract,
+      changedFiles: [
+        'frontend/src/app/one.ts',
+        'frontend/src/app/two.ts',
+        'frontend/src/app/three.ts',
+        'frontend/src/app/four.ts',
+        'frontend/src/app/five.ts',
+        'frontend/src/app/six.ts',
+      ],
+    })).toThrow();
+    expect(() => assertRepositoryPhaseContract({
+      ...contract,
+      changedFiles: ['.rah/prd-008/state.json'],
+    })).toThrow();
   });
 });

--- a/frontend/src/components/ChatAssistant.test.tsx
+++ b/frontend/src/components/ChatAssistant.test.tsx
@@ -77,7 +77,13 @@ describe('ChatAssistant', () => {
                         },
                         sensitivity: {
                             confidence: 0.86,
-                            top_levers: [],
+                            top_levers: [
+                                {
+                                    control: 'rh_target',
+                                    direction: 'decrease',
+                                    elasticity: -0.22,
+                                },
+                            ],
                         },
                         constraint_checks: {
                             status: 'pass',
@@ -123,6 +129,8 @@ describe('ChatAssistant', () => {
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
         expect(await screen.findByText('Model-calculated effect')).toBeTruthy();
+        expect(screen.getByText(/Levers: RH target/)).toBeTruthy();
+        expect(screen.queryByText(/rh_target/)).toBeNull();
         expect(screen.getByText(/14d \+17\.493/)).toBeTruthy();
         expect(screen.getByText(/S\/S \+0\.092/)).toBeTruthy();
         expect(screen.getByText(/Confidence 86%/)).toBeTruthy();

--- a/frontend/src/components/ChatAssistant.tsx
+++ b/frontend/src/components/ChatAssistant.tsx
@@ -15,7 +15,10 @@ import { API_URL } from '../config';
 import { useLocale } from '../i18n/LocaleProvider';
 import { getReadinessDescriptor } from '../lib/design/readiness';
 import { buildAiDashboardContext } from '../utils/aiDashboardContext';
-import { getCropLabel } from '../utils/displayCopy';
+import {
+    getControlDisplayCopy,
+    getCropLabel,
+} from '../utils/displayCopy';
 import type { SmartGrowKnowledgeSummary } from '../hooks/useSmartGrowKnowledge';
 import type {
     AdvisorDisplayPayload,
@@ -60,14 +63,6 @@ type ChatMessage = {
     display?: AdvisorDisplayPayload | null;
     modelRuntime?: ModelRuntimePayload | null;
 };
-
-const CONTROL_LABELS = {
-    co2_setpoint_day: { ko: '주간 CO2', en: 'Day CO2' },
-    temperature_day: { ko: '주간 온도', en: 'Day temperature' },
-    temperature_night: { ko: '야간 온도', en: 'Night temperature' },
-    rh_target: { ko: '습도 목표', en: 'RH target' },
-    screen_close: { ko: '스크린 개폐', en: 'Screen close' },
-} as const;
 
 function formatRuntimeValue(
     value: number | null | undefined,
@@ -588,7 +583,7 @@ const ChatAssistant = ({
                     ) : null}
                     {topLevers.map((lever) => {
                         const controlKey = String(lever.control ?? '');
-                        const label = CONTROL_LABELS[controlKey as keyof typeof CONTROL_LABELS]?.[locale] ?? controlKey;
+                        const label = getControlDisplayCopy(controlKey, locale).compactLabel;
                         return (
                             <span
                                 key={`${controlKey}-${lever.direction}`}

--- a/frontend/src/components/RTROptimizerPanel.tsx
+++ b/frontend/src/components/RTROptimizerPanel.tsx
@@ -23,7 +23,7 @@ import type {
 } from '../types';
 import { useLocale } from '../i18n/LocaleProvider';
 import { getReadinessDescriptor } from '../lib/design/readiness';
-import { getCropLabel } from '../utils/displayCopy';
+import { getControlDisplayCopy, getCropLabel } from '../utils/displayCopy';
 import { getRequestErrorCopy } from '../utils/requestErrorCopy';
 import { useAreaUnit } from '../context/AreaUnitContext';
 import { useRtrOptimizer } from '../hooks/useRtrOptimizer';
@@ -313,6 +313,11 @@ function getReasonTagLabel(code: string, locale: 'en' | 'ko'): string {
 }
 
 function getSensitivityControlLabel(code: string, locale: 'en' | 'ko', crop?: CropType): string {
+    const sharedControlCopy = getControlDisplayCopy(code, locale);
+    if (!sharedControlCopy.fallback) {
+        return sharedControlCopy.compactLabel;
+    }
+
     const koMap: Record<string, string> = {
         day_heating_min_temp_C: '주간 난방 기준',
         night_heating_min_temp_C: '야간 난방 기준',
@@ -321,10 +326,7 @@ function getSensitivityControlLabel(code: string, locale: 'en' | 'ko', crop?: Cr
         vent_bias_C: '환기 편차',
         screen_bias_pct: '스크린 편차',
         circulation_fan_pct: '순환팬 강도',
-        co2_target_ppm: 'CO₂ 목표',
         target_node_rate_day: '목표 마디 전개',
-        temperature_day: '주간 온도',
-        temperature_night: '야간 온도',
         temperature_mean: '평균 온도',
         screen_bias: '스크린 편차',
     };
@@ -336,10 +338,7 @@ function getSensitivityControlLabel(code: string, locale: 'en' | 'ko', crop?: Cr
         vent_bias_C: 'Vent bias',
         screen_bias_pct: 'Screen bias',
         circulation_fan_pct: 'Circulation fan',
-        co2_target_ppm: 'CO2 target',
         target_node_rate_day: 'Target node rate',
-        temperature_day: 'Day temperature',
-        temperature_night: 'Night temperature',
         temperature_mean: 'Mean temperature',
         screen_bias: 'Screen bias',
     };

--- a/frontend/src/components/advisor/AdvisorModelRuntimePanel.test.tsx
+++ b/frontend/src/components/advisor/AdvisorModelRuntimePanel.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { LOCALE_STORAGE_KEY } from '../../i18n/locale';
+import type { ModelRuntimePayload } from '../../hooks/useSmartGrowAdvisor';
+import AdvisorModelRuntimePanel from './AdvisorModelRuntimePanel';
+
+function createRuntime(
+    overrides: Partial<ModelRuntimePayload> = {},
+): ModelRuntimePayload {
+    return {
+        status: 'ready',
+        summary: 'Scenario ready.',
+        state_snapshot: {
+            lai: 3.2,
+            source_sink_balance: 0.12,
+            canopy_net_assimilation_umol_m2_s: 14.5,
+            observed_signal_score: 0.82,
+        },
+        scenario: {
+            baseline_outputs: [],
+            options: [{
+                action: 'Lower humidity target.',
+                time_window: 'now',
+                control: 'rh_target',
+                direction: 'decrease',
+                delta: -3,
+                unit: '%p',
+                score: 0.74,
+                violated_constraints: [],
+            }],
+            recommended: null,
+        },
+        sensitivity: {
+            confidence: 0.8,
+            top_levers: [{
+                control: 'rh_target',
+                direction: 'decrease',
+                elasticity: -0.21,
+                trust_region: {
+                    low: -5,
+                    high: 5,
+                },
+                scenario_alignment: true,
+            }],
+        },
+        constraint_checks: {
+            status: 'pass',
+            violated_constraints: [],
+        },
+        recommendations: [],
+        ...overrides,
+    };
+}
+
+function renderPanel(runtime: ModelRuntimePayload, locale: 'ko' | 'en' = 'en') {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+    render(
+        <LocaleProvider>
+            <AdvisorModelRuntimePanel runtime={runtime} />
+        </LocaleProvider>,
+    );
+}
+
+describe('AdvisorModelRuntimePanel friendly copy', () => {
+    it('keeps the no-violation scenario badge readable', () => {
+        renderPanel(createRuntime(), 'en');
+
+        expect(screen.getByText('No violations')).toBeTruthy();
+        expect(screen.queryByText('Operating constraint needs review')).toBeNull();
+    });
+
+    it('renders mapped constraint copy without backend identifiers', () => {
+        renderPanel(createRuntime({
+            constraint_checks: {
+                status: 'fail',
+                violated_constraints: [{
+                    code: 'humidity_floor_risk',
+                    control: 'rh_target',
+                    severity: 'medium',
+                    message: 'Resulting RH falls below the bounded recovery floor.',
+                }],
+            },
+        }), 'ko');
+
+        expect(screen.getByText('습도 회복 하한 위험')).toBeTruthy();
+        expect(screen.queryByText(/humidity_floor_risk/)).toBeNull();
+        expect(screen.queryByText(/rh_target/)).toBeNull();
+        expect(screen.queryByText(/bounded recovery floor/)).toBeNull();
+    });
+});

--- a/frontend/src/components/advisor/AdvisorModelRuntimePanel.tsx
+++ b/frontend/src/components/advisor/AdvisorModelRuntimePanel.tsx
@@ -1,19 +1,15 @@
 import type { ModelRuntimePayload } from '../../hooks/useSmartGrowAdvisor';
 import { useLocale } from '../../i18n/LocaleProvider';
-import { getLocalizedTokenLabel } from '../../utils/displayCopy';
+import {
+    getControlDisplayCopy,
+    getLocalizedTokenLabel,
+    getRuntimeConstraintDisplayCopy,
+} from '../../utils/displayCopy';
 import AdvisorConfidenceBadge from './AdvisorConfidenceBadge';
 
 interface AdvisorModelRuntimePanelProps {
     runtime?: ModelRuntimePayload | null;
 }
-
-const CONTROL_LABELS = {
-    co2_setpoint_day: { ko: '주간 CO2', en: 'Day CO2' },
-    temperature_day: { ko: '주간 온도', en: 'Day temperature' },
-    temperature_night: { ko: '야간 온도', en: 'Night temperature' },
-    rh_target: { ko: '상대습도 목표', en: 'RH target' },
-    screen_close: { ko: '스크린 폐쇄', en: 'Screen close' },
-} as const;
 
 const TIME_WINDOW_LABELS = {
     now: { ko: '지금', en: 'Now' },
@@ -286,7 +282,7 @@ const AdvisorModelRuntimePanel = ({
                                     </div>
                                 ) : topLevers.map((lever) => {
                                     const controlKey = String(lever.control ?? '');
-                                    const localizedControl = CONTROL_LABELS[controlKey as keyof typeof CONTROL_LABELS];
+                                    const localizedControl = getControlDisplayCopy(controlKey, locale);
                                     const width = clampPercent((Math.abs(Number(lever.elasticity ?? 0)) / maxElasticity) * 100);
                                     return (
                                         <div
@@ -296,9 +292,7 @@ const AdvisorModelRuntimePanel = ({
                                             <div className="flex items-center justify-between gap-3">
                                                 <div>
                                                     <div className="text-sm font-semibold text-[color:var(--sg-text-strong)]">
-                                                        {localizedControl
-                                                            ? localizedControl[locale]
-                                                            : controlKey}
+                                                        {localizedControl.label}
                                                     </div>
                                                     <div className="mt-1 text-xs uppercase tracking-[0.14em] text-[color:var(--sg-text-faint)]">
                                                         {copy.elasticity}
@@ -387,22 +381,26 @@ const AdvisorModelRuntimePanel = ({
                                                 <div>{copy.balanceDelta}: <span className="sg-data-number">{formatNumber(option.expected_source_sink_balance_delta, 2)}</span></div>
                                             </div>
                                             <div className="mt-3 flex flex-wrap gap-2">
-                                                {(optionViolations.length
-                                                    ? optionViolations
-                                                    : [{ code: copy.noViolations, severity: 'success', message: copy.noViolations }]
-                                                ).map((violation, index) => (
-                                                    <AdvisorConfidenceBadge
-                                                        key={`${option.action}-${violation.code}-${index}`}
-                                                        label={getLocalizedTokenLabel(violation.code, locale)}
-                                                        tone={
-                                                            violation.severity === 'high'
-                                                                ? 'danger'
-                                                                : violation.severity === 'medium'
-                                                                    ? 'warning'
-                                                                    : 'success'
-                                                        }
-                                                    />
-                                                ))}
+                                                {optionViolations.length
+                                                    ? optionViolations.map((violation, index) => (
+                                                        <AdvisorConfidenceBadge
+                                                            key={`${option.action}-${violation.code}-${index}`}
+                                                            label={getRuntimeConstraintDisplayCopy(violation, locale).title}
+                                                            tone={
+                                                                violation.severity === 'high'
+                                                                    ? 'danger'
+                                                                    : violation.severity === 'medium'
+                                                                        ? 'warning'
+                                                                        : 'success'
+                                                            }
+                                                        />
+                                                    ))
+                                                    : (
+                                                        <AdvisorConfidenceBadge
+                                                            label={copy.noViolations}
+                                                            tone="success"
+                                                        />
+                                                    )}
                                             </div>
                                         </div>
                                     );
@@ -417,13 +415,16 @@ const AdvisorModelRuntimePanel = ({
                                 {copy.constraintsTitle}
                             </div>
                             <div className="mt-3 flex flex-wrap gap-2">
-                                {violations.map((violation, index) => (
-                                    <AdvisorConfidenceBadge
-                                        key={`${violation.code}-${index}`}
-                                        label={`${getLocalizedTokenLabel(violation.code, locale)}${violation.control ? `:${getLocalizedTokenLabel(violation.control, locale)}` : ''}`}
-                                        tone={violation.severity === 'high' ? 'danger' : 'warning'}
-                                    />
-                                ))}
+                                {violations.map((violation, index) => {
+                                    const constraintCopy = getRuntimeConstraintDisplayCopy(violation, locale);
+                                    return (
+                                        <AdvisorConfidenceBadge
+                                            key={`${violation.code}-${index}`}
+                                            label={constraintCopy.title}
+                                            tone={violation.severity === 'high' ? 'danger' : 'warning'}
+                                        />
+                                    );
+                                })}
                             </div>
                         </div>
                     ) : null}

--- a/frontend/src/components/alerts/AlertsCommandCenter.tsx
+++ b/frontend/src/components/alerts/AlertsCommandCenter.tsx
@@ -160,6 +160,11 @@ export default function AlertsCommandCenter({
                                 </StatusChip>
                                 <div className="mt-2 text-base font-semibold tracking-[-0.03em]">{item.title}</div>
                                 <p className="mt-2 text-sm leading-6 text-[color:var(--sg-text-muted)]">{item.body}</p>
+                                {item.auxiliaryText ? (
+                                    <p className="mt-1 text-xs font-medium leading-5 text-[color:var(--sg-text-faint)]">
+                                        {item.auxiliaryText}
+                                    </p>
+                                ) : null}
                             </article>
                         ))}
                     </div>

--- a/frontend/src/components/dashboard/AlertRail.tsx
+++ b/frontend/src/components/dashboard/AlertRail.tsx
@@ -9,6 +9,7 @@ export interface AlertRailItem {
     severity: 'critical' | 'warning' | 'info' | 'resolved';
     title: string;
     body: string;
+    auxiliaryText?: string;
 }
 
 interface AlertRailProps {
@@ -180,6 +181,11 @@ export default function AlertRail({ items, compact = false }: AlertRailProps) {
                                         <p className="mt-1 text-xs leading-5 opacity-90" style={clampTwoStyle}>
                                             {item.body}
                                         </p>
+                                        {item.auxiliaryText ? (
+                                            <div className="mt-1 text-[10px] font-medium leading-4 text-[color:var(--sg-text-faint)]" style={clampOneStyle}>
+                                                {item.auxiliaryText}
+                                            </div>
+                                        ) : null}
                                     </div>
                                 </div>
                             </article>
@@ -225,6 +231,11 @@ export default function AlertRail({ items, compact = false }: AlertRailProps) {
                                 <p className="mt-2 text-sm leading-6 text-[color:var(--sg-text-muted)]">
                                     {leadItem ? leadItem.body : copy.empty}
                                 </p>
+                                {leadItem?.auxiliaryText ? (
+                                    <div className="mt-2 inline-flex max-w-full rounded-full bg-white/80 px-2.5 py-1 text-[11px] font-medium text-[color:var(--sg-text-faint)]">
+                                        <span className="truncate">{leadItem.auxiliaryText}</span>
+                                    </div>
+                                ) : null}
                                 {leadItem ? (
                                     <div className="mt-3 flex flex-wrap gap-2">
                                         <StatusChip tone="warning">{copy.checkNow}</StatusChip>
@@ -278,6 +289,11 @@ export default function AlertRail({ items, compact = false }: AlertRailProps) {
                                             <StatusChip tone={meta.chipTone} className="px-2 py-0.5 text-[10px]">{copy.severity[item.severity]}</StatusChip>
                                             <div className="mt-1.5 text-sm font-bold text-[color:var(--sg-text-strong)]">{item.title}</div>
                                             <p className="mt-1 text-xs leading-5 text-[color:var(--sg-text-muted)]" style={clampTwoStyle}>{item.body}</p>
+                                            {item.auxiliaryText ? (
+                                                <div className="mt-1 text-[10px] font-medium leading-4 text-[color:var(--sg-text-faint)]" style={clampOneStyle}>
+                                                    {item.auxiliaryText}
+                                                </div>
+                                            ) : null}
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/src/components/dashboard/ModelScenarioWorkbench.tsx
+++ b/frontend/src/components/dashboard/ModelScenarioWorkbench.tsx
@@ -3,6 +3,7 @@ import { Activity, Calculator, FlaskConical, Gauge, Sigma } from 'lucide-react';
 import { useModelRuntimeWorkbench, type ModelScenarioControls } from '../../hooks/useModelRuntimeWorkbench';
 import { useLocale } from '../../i18n/LocaleProvider';
 import type { CropType } from '../../types';
+import { getControlDisplayCopy } from '../../utils/displayCopy';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Select } from '../ui/select';
@@ -13,13 +14,13 @@ interface ModelScenarioWorkbenchProps {
   crop: CropType;
 }
 
-const CONTROL_LABELS: Record<string, { ko: string; en: string; unit: string }> = {
-  temperature_day: { ko: '주간 온도', en: 'Day temp', unit: 'C' },
-  temperature_night: { ko: '야간 온도', en: 'Night temp', unit: 'C' },
-  co2_setpoint_day: { ko: 'CO2', en: 'CO2', unit: 'ppm' },
-  rh_target: { ko: '상대습도', en: 'RH', unit: '%p' },
-  screen_close: { ko: '스크린', en: 'Screen', unit: '%p' },
-};
+const MODEL_SCENARIO_CONTROL_KEYS = [
+  'temperature_day',
+  'temperature_night',
+  'co2_setpoint_day',
+  'rh_target',
+  'screen_close',
+] as const;
 
 const SENSITIVITY_TARGETS = [
   'predicted_yield_24h',
@@ -175,19 +176,22 @@ export default function ModelScenarioWorkbench({ crop }: ModelScenarioWorkbenchP
               {copy.inputs}
             </div>
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-1">
-              {Object.entries(CONTROL_LABELS).map(([key, meta]) => (
-                <label key={key} className="text-xs font-semibold text-[color:var(--sg-text-muted)]">
-                  <span>{locale === 'ko' ? meta.ko : meta.en} ({meta.unit})</span>
-                  <Input
-                    className="mt-1"
-                    type="number"
-                    step={key === 'co2_setpoint_day' ? 10 : 0.1}
-                    value={controls[key as keyof typeof controls]}
-                    onChange={(event) => setControls((current) => ({ ...current, [key]: event.target.value }))}
-                    aria-label={`${locale === 'ko' ? meta.ko : meta.en} delta`}
-                  />
-                </label>
-              ))}
+              {MODEL_SCENARIO_CONTROL_KEYS.map((key) => {
+                const controlCopy = getControlDisplayCopy(key, locale);
+                return (
+                  <label key={key} className="text-xs font-semibold text-[color:var(--sg-text-muted)]">
+                    <span>{controlCopy.compactLabel} ({controlCopy.unit})</span>
+                    <Input
+                      className="mt-1"
+                      type="number"
+                      step={key === 'co2_setpoint_day' ? 10 : 0.1}
+                      value={controls[key as keyof typeof controls]}
+                      onChange={(event) => setControls((current) => ({ ...current, [key]: event.target.value }))}
+                      aria-label={`${controlCopy.compactLabel} delta`}
+                    />
+                  </label>
+                );
+              })}
             </div>
           </div>
 
@@ -236,7 +240,7 @@ export default function ModelScenarioWorkbench({ crop }: ModelScenarioWorkbenchP
                 void runSensitivityWithOptions({
                   target,
                   horizonHours: Number(horizon),
-                  controls: Object.keys(CONTROL_LABELS),
+                  controls: [...MODEL_SCENARIO_CONTROL_KEYS],
                 });
               }}
               disabled={isBusy}
@@ -307,11 +311,11 @@ export default function ModelScenarioWorkbench({ crop }: ModelScenarioWorkbenchP
               <div className="mt-3 grid gap-2 md:grid-cols-2">
                 {sensitivityRows.map((row) => {
                   const control = String(row.control ?? '');
-                  const meta = CONTROL_LABELS[control];
+                  const controlCopy = getControlDisplayCopy(control, locale);
                   return (
                     <div key={control || JSON.stringify(row)} className="rounded-[var(--sg-radius-sm)] border border-[color:var(--sg-outline-soft)] bg-[color:var(--sg-surface-muted)] p-3">
                       <div className="flex items-center justify-between gap-2">
-                        <p className="text-sm font-bold text-[color:var(--sg-text-strong)]">{meta ? (locale === 'ko' ? meta.ko : meta.en) : control}</p>
+                        <p className="text-sm font-bold text-[color:var(--sg-text-strong)]">{controlCopy.compactLabel}</p>
                         <StatusChip tone={row.direction === 'increase' ? 'growth' : row.direction === 'decrease' ? 'warning' : 'muted'}>{String(row.direction ?? '-')}</StatusChip>
                       </div>
                       <dl className="mt-3 grid grid-cols-3 gap-2 text-xs">

--- a/frontend/src/components/dashboard/overviewLandingSections.tsx
+++ b/frontend/src/components/dashboard/overviewLandingSections.tsx
@@ -38,6 +38,7 @@ import { cn } from '../../utils/cn';
 import { metricToneForTile } from '../../utils/metricTone';
 import { AlertCard } from '../ui/alert-card';
 import { Button } from '../ui/button';
+import { GLOBAL_NAVIGATION_ITEMS } from '../../routes/globalNavigation';
 import { Input } from '../ui/input';
 import { MetricCard } from '../ui/metric-card';
 import { SectionHeader } from '../ui/section-header';
@@ -115,8 +116,6 @@ interface TopNavigationProps {
   onOpenAssistant: () => void;
 }
 
-type LandingNavItem = { label: string; to?: string; onClick?: () => void };
-
 function scrollToLandingFooter() {
   if (typeof document === 'undefined') {
     return;
@@ -126,17 +125,6 @@ function scrollToLandingFooter() {
 
 export function TopNavigation({ onOpenAssistant }: TopNavigationProps) {
   const { locale } = useLocale();
-  // Every item resolves to a live destination: hash anchors that only existed on the
-  // retired tabbed overview page were dead, so DASHBOARD/KNOWLEDGE now use real routes
-  // and CONTACT scrolls to the footer contact block.
-  const nav: LandingNavItem[] = [
-    { label: 'HOME', to: '/overview' },
-    { label: 'DASHBOARD', to: '/control' },
-    { label: 'INSIGHTS', to: '/trend' },
-    { label: 'SCENARIOS', to: '/scenarios' },
-    { label: 'KNOWLEDGE', to: '/assistant' },
-    { label: 'CONTACT', onClick: scrollToLandingFooter },
-  ];
   const assistantLabel = locale === 'ko' ? '질문하기' : 'Ask Assistant';
   const dashboardLabel = locale === 'ko' ? '대시보드 열기' : 'Open Dashboard';
 
@@ -148,26 +136,31 @@ export function TopNavigation({ onOpenAssistant }: TopNavigationProps) {
           PhytoSync
         </Link>
         <div className="overview-nav-links">
-          {nav.map((item) => (
-            item.to ? (
+          {GLOBAL_NAVIGATION_ITEMS.map((item) => {
+            const active = item.key === 'home';
+            return item.path ? (
               <Link
-                key={item.label}
-                to={item.to}
-                className="overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
+                key={item.key}
+                to={item.path}
+                aria-current={active ? 'page' : undefined}
+                className={cn(
+                  'overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]',
+                  active && 'overview-nav-link-active',
+                )}
               >
                 {item.label}
               </Link>
             ) : (
               <button
-                key={item.label}
+                key={item.key}
                 type="button"
-                onClick={item.onClick}
+                onClick={scrollToLandingFooter}
                 className="overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]"
               >
                 {item.label}
               </button>
-            )
-          ))}
+            );
+          })}
         </div>
         <div className="flex items-center justify-end gap-2">
           <button

--- a/frontend/src/components/resources/ResourcesCommandCenter.test.tsx
+++ b/frontend/src/components/resources/ResourcesCommandCenter.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { LOCALE_STORAGE_KEY } from '../../i18n/locale';
+import type {
+  AdvancedModelMetrics,
+  ProducePricesPayload,
+  SensorData,
+  WeatherOutlook,
+} from '../../types';
+import ResourcesCommandCenter from './ResourcesCommandCenter';
+
+const currentData: SensorData = {
+  timestamp: Date.parse('2026-04-25T09:00:00+09:00'),
+  temperature: 22.4,
+  canopyTemp: 22.1,
+  humidity: 67,
+  co2: 540,
+  light: 410,
+  soilMoisture: 48,
+  vpd: 1.12,
+  transpiration: 2.4,
+  stomatalConductance: 0.34,
+  photosynthesis: 16.8,
+  hFlux: 44,
+  leFlux: 92,
+  energyUsage: 12.4,
+};
+
+const modelMetrics: AdvancedModelMetrics = {
+  cropType: 'Cucumber',
+  growth: { lai: 3.2, biomass: 124.5, developmentStage: 'vegetative', growthRate: 1.4 },
+  yield: { predictedWeekly: 126.5, confidence: 0.82, harvestableFruits: 48 },
+  energy: { consumption: 12.4, costPrediction: 3800, efficiency: 3.18 },
+};
+
+const weather: WeatherOutlook = {
+  location: { name: 'Daegu', country: 'KR', latitude: 35.87, longitude: 128.6, timezone: 'Asia/Seoul' },
+  source: { provider: 'Open-Meteo', docs_url: 'https://example.test/open-meteo', fetched_at: '2026-04-25T09:00:00+09:00' },
+  summary: 'Clear',
+  current: {
+    time: '2026-04-25T09:00:00+09:00',
+    weather_code: 0,
+    weather_label: 'Clear',
+    temperature_c: 17.8,
+    apparent_temperature_c: 17.1,
+    relative_humidity_pct: 58,
+    precipitation_mm: 0,
+    cloud_cover_pct: 12,
+    wind_speed_kmh: 8.4,
+    wind_direction_deg: 240,
+    is_day: true,
+  },
+  daily: [],
+};
+
+const producePrices: ProducePricesPayload = {
+  source: {
+    provider: 'KAMIS',
+    docs_url: 'https://example.test/kamis',
+    endpoint: '/market/produce',
+    auth_mode: 'configured',
+    fetched_at: '2026-04-25T09:00:00+09:00',
+    latest_day: '2026-04-25',
+  },
+  summary: 'KAMIS snapshot',
+  items: [],
+  markets: {
+    retail: { market_key: 'retail', market_label: 'Retail', summary: 'Retail', items: [] },
+    wholesale: { market_key: 'wholesale', market_label: 'Wholesale', summary: 'Wholesale', items: [] },
+  },
+  trend: {
+    market_key: 'wholesale',
+    reference_date: '2026-04-25',
+    history_days: 14,
+    forecast_days: 7,
+    normal_year_windows: [3, 5, 10],
+    series: [],
+    unavailable_series: [],
+  },
+};
+
+function renderResources(activePanel: 'resources-energy' | 'resources-market' | 'resources-stock') {
+  return render(
+    <LocaleProvider>
+      <ResourcesCommandCenter
+        locale="ko"
+        crop="Cucumber"
+        cropLabel="오이"
+        currentData={currentData}
+        modelMetrics={modelMetrics}
+        weather={weather}
+        weatherLoading={false}
+        weatherError={null}
+        producePrices={producePrices}
+        produceLoading={false}
+        produceError={null}
+        activePanel={activePanel}
+      />
+    </LocaleProvider>,
+  );
+}
+
+describe('PRD-006 ResourcesCommandCenter panel dedup (R19/R20)', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'ko');
+  });
+
+  it('verify_src001_s0006_r003_a01 keeps DecisionSnapshotGrid on the nutrient sub-tab as its decision snapshot', () => {
+    renderResources('resources-stock');
+
+    // R20: the shared DecisionSnapshotGrid data path survives at its /resources home.
+    expect(screen.getByTestId('decision-bridge-card-weather')).toBeTruthy();
+    expect(screen.getByTestId('decision-bridge-card-market')).toBeTruthy();
+    expect(screen.getByTestId('decision-bridge-card-energy')).toBeTruthy();
+    expect(screen.getByTestId('decision-bridge-card-crop')).toBeTruthy();
+  });
+
+  it('verify_src001_s0006_r002_a01 drops the redundant DecisionSnapshotGrid from the energy sub-tab', () => {
+    renderResources('resources-energy');
+
+    // R19: the energy sub-tab no longer double-renders the decision snapshot;
+    // the always-present hero summary cards already carry those four signals.
+    expect(screen.queryByTestId('decision-bridge-card-weather')).toBeNull();
+    expect(screen.queryByTestId('decision-bridge-card-market')).toBeNull();
+    expect(screen.queryByTestId('decision-bridge-card-energy')).toBeNull();
+    expect(screen.queryByTestId('decision-bridge-card-crop')).toBeNull();
+  });
+});

--- a/frontend/src/components/resources/ResourcesCommandCenter.tsx
+++ b/frontend/src/components/resources/ResourcesCommandCenter.tsx
@@ -143,22 +143,11 @@ export default function ResourcesCommandCenter({
             </DashboardCard>
 
             {activePanel === 'resources-energy' ? (
-                <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]">
-                    <WeatherOutlookPanel
-                        weather={weather}
-                        loading={weatherLoading}
-                        error={weatherError}
-                    />
-                    <DecisionSnapshotGrid
-                        crop={crop}
-                        currentData={currentData}
-                        modelMetrics={modelMetrics}
-                        weather={weather}
-                        weatherLoading={weatherLoading}
-                        producePrices={producePrices}
-                        produceLoading={produceLoading}
-                    />
-                </div>
+                <WeatherOutlookPanel
+                    weather={weather}
+                    loading={weatherLoading}
+                    error={weatherError}
+                />
             ) : null}
 
             {activePanel === 'resources-market' ? (

--- a/frontend/src/components/shell/WorkspaceTopNav.test.tsx
+++ b/frontend/src/components/shell/WorkspaceTopNav.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Leaf } from 'lucide-react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { GLOBAL_NAVIGATION_ITEMS } from '../../routes/globalNavigation';
 import WorkspaceTopNav, { type WorkspaceNavItem } from './WorkspaceTopNav';
 
 const ITEMS: WorkspaceNavItem[] = [
@@ -26,14 +28,48 @@ const ITEMS: WorkspaceNavItem[] = [
 ];
 
 describe('WorkspaceTopNav', () => {
-  it('renders route buttons with aria-current on the active workspace', () => {
+  it('renders the shared global navigation with the active top-level page', () => {
     render(
       <LocaleProvider>
-        <WorkspaceTopNav items={ITEMS} activeWorkspace="control" onSelect={() => undefined} />
+        <MemoryRouter>
+          <WorkspaceTopNav
+            globalItems={GLOBAL_NAVIGATION_ITEMS}
+            items={ITEMS}
+            activeGlobalKey="dashboard"
+            activeWorkspace="control"
+            onSelect={() => undefined}
+          />
+        </MemoryRouter>
       </LocaleProvider>,
     );
 
-    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('navigation', { name: 'Global navigation' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'HOME' }).getAttribute('href')).toBe('/overview');
+    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('href')).toBe('/control');
+    expect(screen.getByRole('link', { name: 'INSIGHTS' }).getAttribute('href')).toBe('/trend');
+    expect(screen.getByRole('link', { name: 'SCENARIOS' }).getAttribute('href')).toBe('/scenarios');
+    expect(screen.getByRole('link', { name: 'KNOWLEDGE' }).getAttribute('href')).toBe('/assistant');
+    expect(screen.getByRole('button', { name: 'CONTACT' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'DASHBOARD' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: 'HOME' }).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('renders category subtabs with aria-current step on the active subtab', () => {
+    render(
+      <LocaleProvider>
+        <MemoryRouter>
+          <WorkspaceTopNav
+            globalItems={GLOBAL_NAVIGATION_ITEMS}
+            items={ITEMS}
+            activeGlobalKey="dashboard"
+            activeWorkspace="control"
+            onSelect={() => undefined}
+          />
+        </MemoryRouter>
+      </LocaleProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Control' }).getAttribute('aria-current')).toBe('step');
     expect(screen.getByRole('button', { name: 'Today' }).getAttribute('aria-current')).toBeNull();
   });
 
@@ -41,17 +77,21 @@ describe('WorkspaceTopNav', () => {
     const onSelectAction = vi.fn();
     render(
       <LocaleProvider>
-        <WorkspaceTopNav
-          items={ITEMS}
-          activeWorkspace="control"
-          activeActionId="control-strategy"
-          onSelect={() => undefined}
-          onSelectAction={onSelectAction}
-        />
+        <MemoryRouter>
+          <WorkspaceTopNav
+            globalItems={GLOBAL_NAVIGATION_ITEMS}
+            items={ITEMS}
+            activeGlobalKey="dashboard"
+            activeWorkspace="control"
+            activeActionId="control-strategy"
+            onSelect={() => undefined}
+            onSelectAction={onSelectAction}
+          />
+        </MemoryRouter>
       </LocaleProvider>,
     );
 
-    expect(screen.getByRole('button', { name: 'Strategy' }).getAttribute('aria-current')).toBe('step');
+    expect(screen.getByRole('button', { name: 'Strategy' }).getAttribute('aria-pressed')).toBe('true');
 
     fireEvent.click(screen.getByRole('button', { name: 'Devices' }));
     expect(onSelectAction).toHaveBeenCalledWith('control', 'control-devices');
@@ -60,7 +100,16 @@ describe('WorkspaceTopNav', () => {
   it('renders no sub-action row for a workspace without actions', () => {
     render(
       <LocaleProvider>
-        <WorkspaceTopNav items={ITEMS} activeWorkspace="command" onSelect={() => undefined} onSelectAction={() => undefined} />
+        <MemoryRouter>
+          <WorkspaceTopNav
+            globalItems={GLOBAL_NAVIGATION_ITEMS}
+            items={ITEMS}
+            activeGlobalKey="home"
+            activeWorkspace="command"
+            onSelect={() => undefined}
+            onSelectAction={() => undefined}
+          />
+        </MemoryRouter>
       </LocaleProvider>,
     );
 

--- a/frontend/src/components/shell/WorkspaceTopNav.tsx
+++ b/frontend/src/components/shell/WorkspaceTopNav.tsx
@@ -1,5 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useLocale } from '../../i18n/LocaleProvider';
+import type { GlobalNavigationItem, GlobalNavigationKey } from '../../routes/globalNavigation';
 import { cn } from '../../utils/cn';
 
 export type DashboardWorkspaceKey =
@@ -28,23 +30,31 @@ export interface WorkspaceNavItem {
 }
 
 interface WorkspaceTopNavProps {
+  globalItems: readonly GlobalNavigationItem[];
   items: WorkspaceNavItem[];
+  activeGlobalKey?: GlobalNavigationKey | null;
   activeWorkspace: string;
   activeActionId?: string;
+  onSelectGlobal?: (key: GlobalNavigationKey) => void;
+  onSelectContact?: () => void;
   onSelect: (workspace: string) => void;
   onSelectAction?: (workspace: string, actionId: string) => void;
 }
 
 /**
- * Horizontal workspace navigation strip rendered above route content, replacing
- * the former left WorkspaceNav sidebar. Reuses the Command landing tab-strip
- * classes so workspace routes share the landing's navigation look. The active
- * workspace's sub-actions render as a second chip row (aria-current="step").
+ * Horizontal workspace navigation rendered above route content. The first row
+ * is the global navigation shared with the landing page; the second row only
+ * shows subtabs that belong to the active global category. Route-local panel
+ * actions stay below the subtab row.
  */
 export default function WorkspaceTopNav({
+  globalItems,
   items,
+  activeGlobalKey,
   activeWorkspace,
   activeActionId,
+  onSelectGlobal,
+  onSelectContact,
   onSelect,
   onSelectAction,
 }: WorkspaceTopNavProps) {
@@ -55,29 +65,66 @@ export default function WorkspaceTopNav({
   return (
     <div className="mb-5 grid gap-2">
       <nav
-        aria-label={locale === 'ko' ? '워크스페이스 내비게이션' : 'Workspace navigation'}
-        data-testid="workspace-top-nav"
-        className="overview-tab-strip"
+        aria-label={locale === 'ko' ? '전역 내비게이션' : 'Global navigation'}
+        data-testid="workspace-global-nav"
+        className="overview-nav-links justify-start"
       >
-        {items.map((item) => {
-          const active = item.key === activeWorkspace;
-          return (
+        {globalItems.map((item) => {
+          const active = item.key === activeGlobalKey;
+          const className = cn(
+            'overview-nav-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--sg-color-primary)]',
+            active && 'overview-nav-link-active',
+          );
+
+          return item.path ? (
+            <Link
+              key={item.key}
+              to={item.path}
+              onClick={() => onSelectGlobal?.(item.key)}
+              aria-current={active ? 'page' : undefined}
+              className={className}
+            >
+              {item.label}
+            </Link>
+          ) : (
             <button
               key={item.key}
               type="button"
-              onClick={() => onSelect(item.key)}
+              onClick={onSelectContact}
               aria-current={active ? 'page' : undefined}
-              title={item.description}
-              className={cn('overview-tab-link', active && 'overview-tab-link-active')}
+              className={className}
             >
-              <span>{item.label}</span>
+              {item.label}
             </button>
           );
         })}
       </nav>
+      {items.length > 0 ? (
+        <nav
+          aria-label={locale === 'ko' ? '카테고리 서브탭 내비게이션' : 'Category subtab navigation'}
+          data-testid="workspace-top-nav"
+          className="overview-tab-strip"
+        >
+          {items.map((item) => {
+            const active = item.key === activeWorkspace;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => onSelect(item.key)}
+                aria-current={active ? 'step' : undefined}
+                title={item.description}
+                className={cn('overview-tab-link', active && 'overview-tab-link-active')}
+              >
+                <span>{item.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      ) : null}
       {actions.length > 0 && onSelectAction ? (
         <nav
-          aria-label={locale === 'ko' ? '섹션 내비게이션' : 'Section navigation'}
+          aria-label={locale === 'ko' ? '패널 액션 내비게이션' : 'Panel action navigation'}
           data-testid="workspace-top-nav-actions"
           className="flex flex-wrap items-center gap-1.5"
         >
@@ -88,7 +135,8 @@ export default function WorkspaceTopNav({
                 key={action.id}
                 type="button"
                 onClick={() => onSelectAction(activeWorkspace, action.id)}
-                aria-current={active ? 'step' : undefined}
+                aria-pressed={active}
+                data-active={active}
                 className={cn(
                   'rounded-full border px-3 py-1 text-[0.68rem] font-bold transition',
                   active

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -163,16 +163,18 @@
     padding: 0.26rem 0;
     font-size: 0.65rem;
     font-weight: 700;
-    letter-spacing: 0.04em;
+    letter-spacing: 0;
     text-transform: uppercase;
     color: var(--sg-text-muted);
   }
 
-  .overview-nav-link:first-child {
+  .overview-nav-link-active,
+  .overview-nav-link[aria-current="page"] {
     color: var(--sg-text-strong);
   }
 
-  .overview-nav-link:first-child::after {
+  .overview-nav-link-active::after,
+  .overview-nav-link[aria-current="page"]::after {
     content: "";
     position: absolute;
     right: 0;

--- a/frontend/src/pages/control-page.tsx
+++ b/frontend/src/pages/control-page.tsx
@@ -9,7 +9,6 @@ interface ControlPageProps {
   strategySurface: ReactNode;
   controlActions: ReactNode;
   controlSummary: ReactNode;
-  runtimeSurface?: ReactNode;
 }
 
 export default function ControlPage({
@@ -18,7 +17,6 @@ export default function ControlPage({
   strategySurface,
   controlActions,
   controlSummary,
-  runtimeSurface,
 }: ControlPageProps) {
   const copy = locale === 'ko'
     ? {
@@ -41,15 +39,13 @@ export default function ControlPage({
     >
       {activePanel === 'control-strategy' ? (
         <div className="grid min-w-0 grid-cols-1 gap-5 xl:grid-cols-12">
-          {runtimeSurface ? <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{runtimeSurface}</div> : null}
-          <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlActions}</div>
           <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{strategySurface}</div>
           <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{controlSummary}</div>
+          <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlActions}</div>
         </div>
       ) : null}
       {activePanel === 'control-devices' ? (
         <div className="grid min-w-0 grid-cols-1 gap-5 xl:grid-cols-12">
-          {runtimeSurface ? <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{runtimeSurface}</div> : null}
           <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlSummary}</div>
           <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlActions}</div>
         </div>

--- a/frontend/src/pages/control-page.tsx
+++ b/frontend/src/pages/control-page.tsx
@@ -7,7 +7,6 @@ interface ControlPageProps {
   locale: 'ko' | 'en';
   activePanel: ControlPagePanelId;
   strategySurface: ReactNode;
-  controlActions: ReactNode;
   controlSummary: ReactNode;
 }
 
@@ -15,7 +14,6 @@ export default function ControlPage({
   locale,
   activePanel,
   strategySurface,
-  controlActions,
   controlSummary,
 }: ControlPageProps) {
   const copy = locale === 'ko'
@@ -41,13 +39,11 @@ export default function ControlPage({
         <div className="grid min-w-0 grid-cols-1 gap-5 xl:grid-cols-12">
           <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{strategySurface}</div>
           <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{controlSummary}</div>
-          <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlActions}</div>
         </div>
       ) : null}
       {activePanel === 'control-devices' ? (
         <div className="grid min-w-0 grid-cols-1 gap-5 xl:grid-cols-12">
           <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlSummary}</div>
-          <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{controlActions}</div>
         </div>
       ) : null}
     </PageCanvas>

--- a/frontend/src/pages/control-route-page.tsx
+++ b/frontend/src/pages/control-route-page.tsx
@@ -7,12 +7,10 @@ import type {
   RtrProfile,
   SensorData,
   TemperatureSettings,
-  TelemetryStatus,
   WeatherOutlook,
 } from '../types';
 import type { AlertRailItem } from '../components/dashboard/AlertRail';
 import AlertRail from '../components/dashboard/AlertRail';
-import SimulationRuntimePanel from '../components/dashboard/SimulationRuntimePanel';
 import ControlPanel from '../components/ControlPanel';
 import type { RTROptimizerStateLike, RTROptimizerUiStateLike } from '../components/RTROptimizerPanel';
 import LoadingSkeleton from '../features/common/LoadingSkeleton';
@@ -24,8 +22,6 @@ interface ControlRoutePageProps {
   locale: AppLocale;
   activePanel?: ControlPagePanelId;
   crop: CropType;
-  telemetryStatus: TelemetryStatus;
-  telemetryDetail?: string | null;
   controls: ControlStatus;
   onToggle: (key: keyof ControlStatus) => void;
   onSettingsChange: (settings: TemperatureSettings) => void;
@@ -51,8 +47,6 @@ export default function ControlRoutePage({
   locale,
   activePanel = 'control-strategy',
   crop,
-  telemetryStatus,
-  telemetryDetail = null,
   controls,
   onToggle,
   onSettingsChange,
@@ -125,14 +119,6 @@ export default function ControlRoutePage({
         />
       )}
       controlActions={<AlertRail items={fallbackAlerts} compact />}
-      runtimeSurface={(
-        <SimulationRuntimePanel
-          locale={locale}
-          crop={crop}
-          telemetryStatus={telemetryStatus}
-          telemetryDetail={telemetryDetail}
-        />
-      )}
     />
   );
 }

--- a/frontend/src/pages/control-route-page.tsx
+++ b/frontend/src/pages/control-route-page.tsx
@@ -9,8 +9,6 @@ import type {
   TemperatureSettings,
   WeatherOutlook,
 } from '../types';
-import type { AlertRailItem } from '../components/dashboard/AlertRail';
-import AlertRail from '../components/dashboard/AlertRail';
 import ControlPanel from '../components/ControlPanel';
 import type { RTROptimizerStateLike, RTROptimizerUiStateLike } from '../components/RTROptimizerPanel';
 import LoadingSkeleton from '../features/common/LoadingSkeleton';
@@ -25,8 +23,6 @@ interface ControlRoutePageProps {
   controls: ControlStatus;
   onToggle: (key: keyof ControlStatus) => void;
   onSettingsChange: (settings: TemperatureSettings) => void;
-  alertItems: AlertRailItem[];
-  fallbackAlertBody: string;
   history: SensorData[];
   currentData: SensorData;
   weather: WeatherOutlook | null;
@@ -50,8 +46,6 @@ export default function ControlRoutePage({
   controls,
   onToggle,
   onSettingsChange,
-  alertItems,
-  fallbackAlertBody,
   history,
   currentData,
   weather,
@@ -67,15 +61,6 @@ export default function ControlRoutePage({
   optimizerState,
   uiState,
 }: ControlRoutePageProps) {
-  const fallbackAlerts = alertItems.length
-    ? alertItems
-    : [{
-        id: 'control-ready',
-        severity: 'resolved' as const,
-        title: locale === 'ko' ? '제어 차단 항목 없음' : 'No urgent warning',
-        body: fallbackAlertBody,
-      }];
-
   return (
     <ControlPage
       locale={locale}
@@ -118,7 +103,6 @@ export default function ControlRoutePage({
           onSettingsChange={onSettingsChange}
         />
       )}
-      controlActions={<AlertRail items={fallbackAlerts} compact />}
     />
   );
 }

--- a/frontend/src/pages/crop-work-page.tsx
+++ b/frontend/src/pages/crop-work-page.tsx
@@ -4,7 +4,6 @@ import PageCanvas from '../components/layout/PageCanvas';
 interface CropWorkPageProps {
   locale: 'ko' | 'en';
   cropSummary: ReactNode;
-  workBoard: ReactNode;
   forecastSurface: ReactNode;
   recentWorkSurface: ReactNode;
   activeTabId?: string;
@@ -13,7 +12,6 @@ interface CropWorkPageProps {
 export default function CropWorkPage({
   locale,
   cropSummary,
-  workBoard,
   forecastSurface,
   recentWorkSurface,
   activeTabId,
@@ -45,31 +43,27 @@ export default function CropWorkPage({
       <div className="grid min-w-0 grid-cols-1 gap-5 xl:grid-cols-12">
         {showGrowth ? (
           <>
-            <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{cropSummary}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{workBoard}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{forecastSurface}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-6 [&>*]:h-full">{cropSummary}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-6 [&>*]:h-full">{forecastSurface}</div>
           </>
         ) : null}
         {showWork ? (
           <>
-            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{workBoard}</div>
             <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{recentWorkSurface}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{cropSummary}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{cropSummary}</div>
           </>
         ) : null}
         {showHarvest ? (
           <>
             <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{recentWorkSurface}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{workBoard}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{forecastSurface}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{forecastSurface}</div>
           </>
         ) : null}
         {!showGrowth && !showWork && !showHarvest ? (
           <>
-            <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{cropSummary}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{workBoard}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-6 [&>*]:h-full">{forecastSurface}</div>
-            <div className="min-h-0 min-w-0 xl:col-span-6 [&>*]:h-full">{recentWorkSurface}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-4 [&>*]:h-full">{cropSummary}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-8 [&>*]:h-full">{forecastSurface}</div>
+            <div className="min-h-0 min-w-0 xl:col-span-12 [&>*]:h-full">{recentWorkSurface}</div>
           </>
         ) : null}
       </div>

--- a/frontend/src/pages/crop-work-route-page.tsx
+++ b/frontend/src/pages/crop-work-route-page.tsx
@@ -1,7 +1,5 @@
 import { Suspense, lazy } from 'react';
 import CropDetails from '../components/CropDetails';
-import TodayBoard from '../components/dashboard/TodayBoard';
-import ModelRuntimeBridge from '../components/dashboard/ModelRuntimeBridge';
 import LoadingSkeleton from '../features/common/LoadingSkeleton';
 import type { AppLocale } from '../i18n/locale';
 import type { AdvancedModelMetrics, CropType, ForecastData, SensorData } from '../types';
@@ -17,12 +15,7 @@ interface CropWorkRoutePageProps {
   modelMetrics: AdvancedModelMetrics;
   forecast: ForecastData | null;
   aiAnalysis: string | null;
-  actionsNow: string[];
-  actionsToday: string[];
-  actionsWeek: string[];
-  monitor: string[];
   activePanel?: 'crop-work-growth' | 'crop-work-work' | 'crop-work-harvest';
-  onOpenAssistant: () => void;
 }
 
 export default function CropWorkRoutePage({
@@ -32,27 +25,13 @@ export default function CropWorkRoutePage({
   modelMetrics,
   forecast,
   aiAnalysis,
-  actionsNow,
-  actionsToday,
-  actionsWeek,
-  monitor,
   activePanel = 'crop-work-growth',
-  onOpenAssistant,
 }: CropWorkRoutePageProps) {
   return (
     <CropWorkPage
       locale={locale}
       activeTabId={activePanel}
       cropSummary={<CropDetails crop={crop} currentData={currentData} metrics={modelMetrics} />}
-      workBoard={(
-        <TodayBoard
-          actionsNow={actionsNow}
-          actionsToday={actionsToday}
-          actionsWeek={actionsWeek}
-          monitor={monitor}
-          compact
-        />
-      )}
       forecastSurface={(
         <Suspense
           fallback={(
@@ -84,10 +63,6 @@ export default function CropWorkRoutePage({
               crop={crop}
             />
           </Suspense>
-          <ModelRuntimeBridge
-            crop={crop}
-            onOpenAssistant={onOpenAssistant}
-          />
         </div>
       )}
     />

--- a/frontend/src/pages/overview-page.test.tsx
+++ b/frontend/src/pages/overview-page.test.tsx
@@ -49,6 +49,29 @@ describe('OverviewPage', () => {
     expect(document.activeElement?.id).toBe('overview-watch');
   });
 
+  it('verify_src001_s0002_r002_a01 resolves contact hash navigation to the landing footer', async () => {
+    render(
+      <LocaleProvider>
+        <MemoryRouter initialEntries={['/overview#contact']}>
+          <OverviewPage
+            topNavigation={<div>nav</div>}
+            heroDecisionBrief={<section id="overview-core" tabIndex={-1}>core</section>}
+            liveMetricStrip={<section id="overview-dashboard" tabIndex={-1}>dashboard</section>}
+            todayActionBoard={<section id="overview-watch" tabIndex={-1}>watch</section>}
+            scenarioOptimizerPreview={<section id="scenario-optimizer">scenario</section>}
+            weatherMarketKnowledgeBridge={<section id="overview-bridge">bridge</section>}
+            finalCta={<section id="contact">contact</section>}
+            footer={<footer id="overview-footer" tabIndex={-1}>footer</footer>}
+            activeTabId="overview-core"
+          />
+        </MemoryRouter>
+      </LocaleProvider>,
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    expect(document.activeElement?.id).toBe('overview-footer');
+  });
+
   it('verify_src001_s0002_r002_a01 renders overview tabs through the shared toggle group contract', () => {
     render(
       <LocaleProvider>

--- a/frontend/src/pages/overview-page.tsx
+++ b/frontend/src/pages/overview-page.tsx
@@ -29,6 +29,8 @@ const OVERVIEW_SECTION_BY_ACTION: Record<string, string> = {
   'backend-runtime-bridge': 'backend-runtime-bridge',
   'live-overview': 'live-overview',
   'today-action-board': 'today-action-board',
+  contact: 'overview-footer',
+  'overview-footer': 'overview-footer',
 };
 
 const OVERVIEW_TAB_IDS = ['overview-core', 'overview-dashboard', 'overview-watch'] as const;

--- a/frontend/src/pages/rtr-route-page.tsx
+++ b/frontend/src/pages/rtr-route-page.tsx
@@ -1,10 +1,7 @@
 import { Suspense, lazy } from 'react';
 import type { AppLocale } from '../i18n/locale';
 import type {
-  AdvancedModelMetrics,
-  ControlStatus,
   CropType,
-  ProducePricesPayload,
   RtrOptimizationMode,
   RtrProfile,
   SensorData,
@@ -12,8 +9,6 @@ import type {
   TelemetryStatus,
   WeatherOutlook,
 } from '../types';
-import ControlPanel from '../components/ControlPanel';
-import DecisionSnapshotGrid from '../components/dashboard/DecisionSnapshotGrid';
 import LoadingSkeleton from '../features/common/LoadingSkeleton';
 import type { RTROptimizerStateLike, RTROptimizerUiStateLike } from '../components/RTROptimizerPanel';
 import RtrPage from './rtr-page';
@@ -36,12 +31,6 @@ interface RtrRoutePageProps {
   optimizerEnabled?: boolean;
   defaultMode?: RtrOptimizationMode;
   onRefreshProfiles?: () => void | Promise<void>;
-  controls: ControlStatus;
-  onToggle: (key: keyof ControlStatus) => void;
-  onSettingsChange: (settings: TemperatureSettings) => void;
-  modelMetrics: AdvancedModelMetrics;
-  producePrices: ProducePricesPayload | null;
-  produceLoading: boolean;
   optimizerState?: RTROptimizerStateLike;
   uiState?: RTROptimizerUiStateLike;
 }
@@ -62,12 +51,6 @@ export default function RtrRoutePage({
   optimizerEnabled,
   defaultMode,
   onRefreshProfiles,
-  controls,
-  onToggle,
-  onSettingsChange,
-  modelMetrics,
-  producePrices,
-  produceLoading,
   optimizerState,
   uiState,
 }: RtrRoutePageProps) {
@@ -104,29 +87,6 @@ export default function RtrRoutePage({
             uiState={uiState}
           />
         </Suspense>
-      )}
-      supportSurface={(
-        <div className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]">
-          <div className="min-h-0 min-w-0 [&>*]:h-full">
-            <ControlPanel
-              status={controls}
-              onToggle={onToggle}
-              onSettingsChange={onSettingsChange}
-            />
-          </div>
-          <div className="min-h-0 min-w-0 [&>*]:h-full">
-            <DecisionSnapshotGrid
-              crop={crop}
-              currentData={currentData}
-              modelMetrics={modelMetrics}
-              weather={weather}
-              weatherLoading={weatherLoading}
-              producePrices={producePrices}
-              produceLoading={produceLoading}
-              history={history}
-            />
-          </div>
-        </div>
       )}
     />
   );

--- a/frontend/src/pages/settings-page.tsx
+++ b/frontend/src/pages/settings-page.tsx
@@ -5,12 +5,14 @@ interface SettingsPageProps {
   locale: 'ko' | 'en';
   shellCard: ReactNode;
   laneCard: ReactNode;
+  runtimeSurface: ReactNode;
 }
 
 export default function SettingsPage({
   locale,
   shellCard,
   laneCard,
+  runtimeSurface,
 }: SettingsPageProps) {
   const copy = locale === 'ko'
     ? {
@@ -26,6 +28,7 @@ export default function SettingsPage({
 
   return (
     <PageCanvas eyebrow={copy.eyebrow} title={copy.title} description={copy.description}>
+      <div className="mb-6 min-w-0">{runtimeSurface}</div>
       <div className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div className="min-w-0">{shellCard}</div>
         <div className="min-w-0">{laneCard}</div>

--- a/frontend/src/pages/settings-route-page.tsx
+++ b/frontend/src/pages/settings-route-page.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import DashboardCard from '../components/common/DashboardCard';
+import SimulationRuntimePanel from '../components/dashboard/SimulationRuntimePanel';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { API_URL } from '../config';
 import type { AppLocale } from '../i18n/locale';
-import type { CropType } from '../types';
+import type { CropType, TelemetryStatus } from '../types';
 import SettingsPage from './settings-page';
 
 interface SettingsRoutePageProps {
@@ -13,6 +14,8 @@ interface SettingsRoutePageProps {
   selectedCropLabel: string;
   assistantOpen: boolean;
   telemetrySummary: string;
+  telemetryStatus: TelemetryStatus;
+  telemetryDetail?: string | null;
   weatherConnected: boolean;
   marketConnected: boolean;
 }
@@ -35,6 +38,8 @@ export default function SettingsRoutePage({
   selectedCropLabel,
   assistantOpen,
   telemetrySummary,
+  telemetryStatus,
+  telemetryDetail = null,
   weatherConnected,
   marketConnected,
 }: SettingsRoutePageProps) {
@@ -138,6 +143,14 @@ export default function SettingsRoutePage({
   return (
     <SettingsPage
       locale={locale}
+      runtimeSurface={(
+        <SimulationRuntimePanel
+          locale={locale}
+          crop={crop}
+          telemetryStatus={telemetryStatus}
+          telemetryDetail={telemetryDetail}
+        />
+      )}
       shellCard={(
         <DashboardCard
           eyebrow={locale === 'ko' ? '표시 기준' : 'Display'}

--- a/frontend/src/pages/workspaceRouteLayoutGuards.test.ts
+++ b/frontend/src/pages/workspaceRouteLayoutGuards.test.ts
@@ -40,8 +40,14 @@ describe('workspace route layout guards', () => {
 
   it('uses minmax(0, ...) tracks for fixed workspace column layouts', () => {
     expect(assistantPageSource).toContain('grid min-w-0 gap-6 2xl:grid-cols-[minmax(0,1fr)_minmax(0,392px)]');
-    expect(rtrRouteSource).toContain('grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]');
     expect(settingsPageSource).toContain('grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]');
+  });
+
+  it('keeps the RTR route as a single optimizer surface without borrowed tab panels', () => {
+    expect(rtrRouteSource).toContain('recommendationSurface');
+    expect(rtrRouteSource).not.toContain('supportSurface');
+    expect(rtrRouteSource).not.toContain('ControlPanel');
+    expect(rtrRouteSource).not.toContain('DecisionSnapshotGrid');
   });
 
   it('guards all xl column-span route grid items against intrinsic-width overflow', () => {
@@ -54,6 +60,5 @@ describe('workspace route layout guards', () => {
     expect(cropWorkRouteSource).toContain('min-w-0 space-y-5');
     expect(countOccurrences(scenariosRouteSource, 'className="min-w-0 scroll-mt-24 focus:outline-none"')).toBe(2);
     expect(settingsRouteSource).toContain('grid min-w-0 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]');
-    expect(countOccurrences(rtrRouteSource, 'className="min-h-0 min-w-0 [&>*]:h-full"')).toBe(2);
   });
 });

--- a/frontend/src/routes/globalNavigation.test.ts
+++ b/frontend/src/routes/globalNavigation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GLOBAL_NAVIGATION_ITEMS,
+  getGlobalNavigationKeyForPathname,
+  getSubNavigationSectionKeys,
+} from './globalNavigation';
+
+describe('globalNavigation', () => {
+  it('verify_src001_s0002_r001_a01 keeps the shared global navigation labels in order', () => {
+    expect(GLOBAL_NAVIGATION_ITEMS.map((item) => item.label)).toEqual([
+      'HOME',
+      'DASHBOARD',
+      'INSIGHTS',
+      'SCENARIOS',
+      'KNOWLEDGE',
+      'CONTACT',
+    ]);
+  });
+
+  it('verify_src001_s0002_r002_a01 keeps the global destinations stable', () => {
+    expect(GLOBAL_NAVIGATION_ITEMS.map((item) => [item.label, item.path ?? null])).toEqual([
+      ['HOME', '/overview'],
+      ['DASHBOARD', '/control'],
+      ['INSIGHTS', '/trend'],
+      ['SCENARIOS', '/scenarios'],
+      ['KNOWLEDGE', '/assistant'],
+      ['CONTACT', null],
+    ]);
+  });
+
+  it('verify_src001_s0002_r003_a01 maps paths to category-specific subtabs', () => {
+    expect(getGlobalNavigationKeyForPathname('/control')).toBe('dashboard');
+    expect(getGlobalNavigationKeyForPathname('/rtr')).toBe('dashboard');
+    expect(getGlobalNavigationKeyForPathname('/crop-work')).toBe('dashboard');
+    expect(getGlobalNavigationKeyForPathname('/resources')).toBe('dashboard');
+    expect(getGlobalNavigationKeyForPathname('/alerts')).toBe('dashboard');
+    expect(getGlobalNavigationKeyForPathname('/trend')).toBe('insights');
+    expect(getGlobalNavigationKeyForPathname('/scenarios')).toBe('scenarios');
+    expect(getGlobalNavigationKeyForPathname('/assistant')).toBe('knowledge');
+    expect(getGlobalNavigationKeyForPathname('/settings')).toBeNull();
+
+    expect(getSubNavigationSectionKeys('dashboard')).toEqual([
+      'control',
+      'rtr',
+      'crop-work',
+      'resources',
+      'alerts',
+    ]);
+    expect(getSubNavigationSectionKeys('insights')).toEqual(['trend']);
+    expect(getSubNavigationSectionKeys('scenarios')).toEqual(['scenarios']);
+    expect(getSubNavigationSectionKeys('knowledge')).toEqual(['assistant']);
+    expect(getSubNavigationSectionKeys(null)).toEqual([]);
+  });
+});

--- a/frontend/src/routes/globalNavigation.ts
+++ b/frontend/src/routes/globalNavigation.ts
@@ -1,0 +1,70 @@
+import type { PhytoSectionKey } from './phytosyncSections';
+
+export type GlobalNavigationKey =
+  | 'home'
+  | 'dashboard'
+  | 'insights'
+  | 'scenarios'
+  | 'knowledge'
+  | 'contact';
+
+export interface GlobalNavigationItem {
+  key: GlobalNavigationKey;
+  label: string;
+  path?: string;
+}
+
+export const GLOBAL_NAVIGATION_ITEMS: readonly GlobalNavigationItem[] = [
+  { key: 'home', label: 'HOME', path: '/overview' },
+  { key: 'dashboard', label: 'DASHBOARD', path: '/control' },
+  { key: 'insights', label: 'INSIGHTS', path: '/trend' },
+  { key: 'scenarios', label: 'SCENARIOS', path: '/scenarios' },
+  { key: 'knowledge', label: 'KNOWLEDGE', path: '/assistant' },
+  { key: 'contact', label: 'CONTACT' },
+] as const;
+
+const DASHBOARD_SUBNAV_SECTION_KEYS = [
+  'control',
+  'rtr',
+  'crop-work',
+  'resources',
+  'alerts',
+] as const satisfies readonly PhytoSectionKey[];
+
+const SUBNAV_SECTION_KEYS_BY_GLOBAL_KEY: Record<GlobalNavigationKey, readonly PhytoSectionKey[]> = {
+  home: [],
+  dashboard: DASHBOARD_SUBNAV_SECTION_KEYS,
+  insights: ['trend'],
+  scenarios: ['scenarios'],
+  knowledge: ['assistant'],
+  contact: [],
+};
+
+export function getGlobalNavigationKeyForPathname(pathname: string): GlobalNavigationKey | null {
+  if (pathname === '/' || pathname.startsWith('/overview')) return 'home';
+  if (pathname.startsWith('/trend')) return 'insights';
+  if (pathname.startsWith('/scenarios')) return 'scenarios';
+  if (pathname.startsWith('/assistant') || pathname.startsWith('/ask')) return 'knowledge';
+
+  if (
+    pathname.startsWith('/control')
+    || pathname.startsWith('/rtr')
+    || pathname.startsWith('/crop-work')
+    || pathname.startsWith('/resources')
+    || pathname.startsWith('/alerts')
+    || pathname.startsWith('/growth')
+    || pathname.startsWith('/harvest')
+    || pathname.startsWith('/nutrient')
+    || pathname.startsWith('/protection')
+  ) {
+    return 'dashboard';
+  }
+
+  return null;
+}
+
+export function getSubNavigationSectionKeys(
+  key: GlobalNavigationKey | null,
+): readonly PhytoSectionKey[] {
+  return key ? SUBNAV_SECTION_KEYS_BY_GLOBAL_KEY[key] : [];
+}

--- a/frontend/src/utils/displayCopy.test.ts
+++ b/frontend/src/utils/displayCopy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONTROL_DISPLAY_COPY,
+  RUNTIME_CONSTRAINT_DISPLAY_COPY,
+  getControlDisplayCopy,
+  getRuntimeConstraintDisplayCopy,
+} from './displayCopy';
+
+describe('displayCopy friendly control and constraint copy', () => {
+  const backendConstraintCodes = [
+    'trust_region_exceeded',
+    'disease_risk_high',
+    'humidity_floor_risk',
+    'screen_humidity_coupling',
+    'heat_stress_risk',
+    'cold_stress_risk',
+    'night_cold_risk',
+    'co2_overdose_risk',
+    'source_loss_risk',
+  ] as const;
+
+  it('keeps a single dictionary for required control and risk identifiers', () => {
+    expect(CONTROL_DISPLAY_COPY.rh_target.label.ko).toBe('상대습도 목표');
+    expect(CONTROL_DISPLAY_COPY.co2_target.label.ko).toBe('이산화탄소 목표');
+    expect(CONTROL_DISPLAY_COPY.heating_set_C.label.ko).toBe('난방 설정 온도');
+    expect(RUNTIME_CONSTRAINT_DISPLAY_COPY.humidity_floor_risk.title.ko).toBe('습도 회복 하한 위험');
+  });
+
+  it('localizes known control identifiers without exposing snake_case labels', () => {
+    expect(getControlDisplayCopy('rh_target', 'ko')).toMatchObject({
+      label: '상대습도 목표',
+      compactLabel: '습도 목표',
+      unit: '%p',
+      fallback: false,
+    });
+    expect(getControlDisplayCopy('co2_setpoint_day', 'en')).toMatchObject({
+      label: 'Day CO₂ target',
+      compactLabel: 'Day CO₂',
+      unit: 'ppm',
+      fallback: false,
+    });
+  });
+
+  it('maps the rh_target humidity floor risk to farmer-friendly Korean alert copy', () => {
+    const copy = getRuntimeConstraintDisplayCopy({
+      control: 'rh_target',
+      code: 'humidity_floor_risk',
+    }, 'ko');
+
+    expect(copy.title).toBe('습도 회복 하한 위험');
+    expect(copy.body).toBe('습도 목표를 낮추면 상대습도가 회복 하한 아래로 떨어질 수 있어요. 현재 설정을 확인해 주세요.');
+    expect(copy.title).not.toContain('rh_target');
+    expect(copy.body).not.toContain('humidity_floor_risk');
+    expect(copy.auxiliaryText).toBeUndefined();
+  });
+
+  it('maps all current backend constraint codes before falling back to source-code text', () => {
+    backendConstraintCodes.forEach((code) => {
+      const copy = getRuntimeConstraintDisplayCopy({
+        control: code === 'co2_overdose_risk' ? 'co2_setpoint_day' : 'rh_target',
+        code,
+      }, 'ko');
+
+      expect(copy.fallback).toBe(false);
+      expect(copy.title.trim()).not.toBe('');
+      expect(copy.body.trim()).not.toBe('');
+      expect(copy.auxiliaryText).toBeUndefined();
+      expect(copy.title).not.toContain(code);
+      expect(copy.body).not.toContain(code);
+    });
+  });
+
+  it('uses non-empty fallback copy and compressed source-code text for unknown constraints', () => {
+    const copy = getRuntimeConstraintDisplayCopy({
+      control: 'unknown_control',
+      code: 'custom_floor_risk',
+    }, 'ko');
+
+    expect(copy.title).toBe('운영 제약 확인 필요');
+    expect(copy.body).toContain('사전에 없는 운영 제약이 감지되었습니다.');
+    expect(copy.title.trim()).not.toBe('');
+    expect(copy.body.trim()).not.toBe('');
+    expect(copy.auxiliaryText).toBe('원문 코드: unknown_control · custom_floor_risk');
+  });
+});

--- a/frontend/src/utils/displayCopy.ts
+++ b/frontend/src/utils/displayCopy.ts
@@ -313,8 +313,271 @@ const COMMON_TOKEN_LABELS: Record<string, { en: string; ko: string }> = {
     score: { en: 'Score', ko: '점수' },
 };
 
+type LocalizedDisplayText = Record<AppLocale, string>;
+
+type ControlDisplayCopyEntry = {
+    label: LocalizedDisplayText;
+    compactLabel?: LocalizedDisplayText;
+    unit: string;
+};
+
+export const CONTROL_DISPLAY_COPY = {
+    temperature_day: {
+        label: { ko: '주간 온도', en: 'Day temperature' },
+        compactLabel: { ko: '주간 온도', en: 'Day temp' },
+        unit: '°C',
+    },
+    temperature_night: {
+        label: { ko: '야간 온도', en: 'Night temperature' },
+        compactLabel: { ko: '야간 온도', en: 'Night temp' },
+        unit: '°C',
+    },
+    co2_target: {
+        label: { ko: '이산화탄소 목표', en: 'CO₂ target' },
+        compactLabel: { ko: 'CO₂ 목표', en: 'CO₂' },
+        unit: 'ppm',
+    },
+    co2_target_ppm: {
+        label: { ko: '이산화탄소 목표', en: 'CO₂ target' },
+        compactLabel: { ko: 'CO₂ 목표', en: 'CO₂' },
+        unit: 'ppm',
+    },
+    co2_setpoint_day: {
+        label: { ko: '주간 이산화탄소 목표', en: 'Day CO₂ target' },
+        compactLabel: { ko: '주간 CO₂', en: 'Day CO₂' },
+        unit: 'ppm',
+    },
+    heating_set_C: {
+        label: { ko: '난방 설정 온도', en: 'Heating set temperature' },
+        compactLabel: { ko: '난방 온도', en: 'Heating set' },
+        unit: '°C',
+    },
+    heating_set_c: {
+        label: { ko: '난방 설정 온도', en: 'Heating set temperature' },
+        compactLabel: { ko: '난방 온도', en: 'Heating set' },
+        unit: '°C',
+    },
+    rh_target: {
+        label: { ko: '상대습도 목표', en: 'Relative humidity target' },
+        compactLabel: { ko: '습도 목표', en: 'RH target' },
+        unit: '%p',
+    },
+    screen_close: {
+        label: { ko: '스크린 폐쇄율', en: 'Screen closure' },
+        compactLabel: { ko: '스크린', en: 'Screen' },
+        unit: '%p',
+    },
+} as const satisfies Record<string, ControlDisplayCopyEntry>;
+
+type RuntimeConstraintDisplayCopyEntry = {
+    title: LocalizedDisplayText;
+    body: LocalizedDisplayText;
+};
+
+export const RUNTIME_CONSTRAINT_DISPLAY_COPY = {
+    'rh_target:humidity_floor_risk': {
+        title: {
+            ko: '습도 회복 하한 위험',
+            en: 'Humidity recovery floor risk',
+        },
+        body: {
+            ko: '습도 목표를 낮추면 상대습도가 회복 하한 아래로 떨어질 수 있어요. 현재 설정을 확인해 주세요.',
+            en: 'Lowering the humidity target can push relative humidity below the recovery floor. Please review the current setting.',
+        },
+    },
+    humidity_floor_risk: {
+        title: {
+            ko: '습도 회복 하한 위험',
+            en: 'Humidity recovery floor risk',
+        },
+        body: {
+            ko: '상대습도가 회복 하한 아래로 떨어질 수 있어요. 현재 설정을 확인해 주세요.',
+            en: 'Relative humidity may fall below the recovery floor. Please review the current setting.',
+        },
+    },
+    trust_region_exceeded: {
+        title: {
+            ko: '안전 조정 범위 초과',
+            en: 'Safe adjustment range exceeded',
+        },
+        body: {
+            ko: '권장 변경량이 모델이 신뢰하는 조정 범위를 벗어났어요. 변경 폭을 줄여 다시 확인해 주세요.',
+            en: 'The requested change is outside the model trust range. Reduce the adjustment and review again.',
+        },
+    },
+    disease_risk_high: {
+        title: {
+            ko: '습도 병해 위험',
+            en: 'Humidity disease-risk warning',
+        },
+        body: {
+            ko: '상대습도가 병해 위험이 커지는 상한에 가까워졌어요. 제습과 환기 상태를 함께 확인해 주세요.',
+            en: 'Relative humidity is near the disease-risk ceiling. Review dehumidification and ventilation together.',
+        },
+    },
+    screen_humidity_coupling: {
+        title: {
+            ko: '스크린-습도 동시 상승 주의',
+            en: 'Screen and humidity coupling warning',
+        },
+        body: {
+            ko: '스크린을 더 닫으면 하부 습도가 함께 높아질 수 있어요. 스크린과 습도 설정을 같이 점검해 주세요.',
+            en: 'Closing the screen further can lift lower-canopy humidity. Review screen and humidity settings together.',
+        },
+    },
+    heat_stress_risk: {
+        title: {
+            ko: '고온 스트레스 위험',
+            en: 'Heat-stress risk',
+        },
+        body: {
+            ko: '주간 온도가 작물 스트레스 기준을 넘을 수 있어요. 냉방, 환기, 차광 여유를 확인해 주세요.',
+            en: 'Day temperature may cross the crop stress threshold. Review cooling, ventilation, and shading margin.',
+        },
+    },
+    cold_stress_risk: {
+        title: {
+            ko: '주간 저온 회복 지연 위험',
+            en: 'Daytime cold recovery risk',
+        },
+        body: {
+            ko: '주간 온도가 회복에 필요한 범위보다 낮아질 수 있어요. 난방 기준과 환기 편차를 확인해 주세요.',
+            en: 'Day temperature may fall below the recovery band. Review heating setpoints and ventilation bias.',
+        },
+    },
+    night_cold_risk: {
+        title: {
+            ko: '야간 저온 위험',
+            en: 'Night cold-risk warning',
+        },
+        body: {
+            ko: '야간 온도가 하한 아래로 내려갈 수 있어요. 야간 난방 기준을 다시 확인해 주세요.',
+            en: 'Night temperature may drop below the floor. Review the night heating setpoint.',
+        },
+    },
+    co2_overdose_risk: {
+        title: {
+            ko: 'CO₂ 과다 보강 위험',
+            en: 'CO₂ over-supply risk',
+        },
+        body: {
+            ko: 'CO₂ 목표가 반응 상한을 넘을 수 있어요. 보강량과 환기 상태를 함께 확인해 주세요.',
+            en: 'The CO₂ target may exceed the high-response band. Review enrichment and ventilation together.',
+        },
+    },
+    source_loss_risk: {
+        title: {
+            ko: '광합성 공급 저하 위험',
+            en: 'Source limitation risk',
+        },
+        body: {
+            ko: '스크린 폐쇄가 현재 소스 부족을 더 키울 수 있어요. 광량 확보와 스크린 설정을 같이 확인해 주세요.',
+            en: 'Additional screen closure may amplify the current source limitation. Review light capture and screen settings.',
+        },
+    },
+} as const satisfies Record<string, RuntimeConstraintDisplayCopyEntry>;
+
+export type ControlDisplayCopy = {
+    code: string;
+    label: string;
+    compactLabel: string;
+    unit: string;
+    fallback: boolean;
+    auxiliaryText?: string;
+};
+
+export type RuntimeConstraintDisplayCopy = {
+    title: string;
+    body: string;
+    auxiliaryText?: string;
+    fallback: boolean;
+};
+
 function normalizeLookupKey(value: string): string {
     return value.trim().toLowerCase().replace(/[_-]+/g, ' ');
+}
+
+function normalizeControlCode(value: string): string {
+    return value.trim().replace(/-/g, '_');
+}
+
+function getSourceCodeText(rawTokens: string[], locale: AppLocale): string | undefined {
+    const compactTokens = rawTokens
+        .map((token) => token.trim())
+        .filter(Boolean);
+
+    if (compactTokens.length === 0) {
+        return undefined;
+    }
+
+    return locale === 'ko'
+        ? `원문 코드: ${compactTokens.join(' · ')}`
+        : `Source code: ${compactTokens.join(' · ')}`;
+}
+
+export function getControlDisplayCopy(
+    controlCode: string | null | undefined,
+    locale: AppLocale,
+): ControlDisplayCopy {
+    const rawCode = String(controlCode ?? '').trim();
+    const normalizedCode = normalizeControlCode(rawCode);
+    const entry = CONTROL_DISPLAY_COPY[normalizedCode as keyof typeof CONTROL_DISPLAY_COPY];
+
+    if (entry) {
+        return {
+            code: rawCode,
+            label: entry.label[locale],
+            compactLabel: (entry.compactLabel ?? entry.label)[locale],
+            unit: entry.unit,
+            fallback: false,
+        };
+    }
+
+    return {
+        code: rawCode,
+        label: locale === 'ko' ? '운영 제어값' : 'Operating control',
+        compactLabel: locale === 'ko' ? '제어값' : 'Control',
+        unit: '',
+        fallback: true,
+        auxiliaryText: getSourceCodeText([rawCode], locale),
+    };
+}
+
+export function getRuntimeConstraintDisplayCopy(
+    violation: {
+        code?: string | null;
+        control?: string | null;
+    },
+    locale: AppLocale,
+): RuntimeConstraintDisplayCopy {
+    const rawCode = String(violation.code ?? '').trim();
+    const rawControl = String(violation.control ?? '').trim();
+    const normalizedCode = normalizeControlCode(rawCode);
+    const normalizedControl = normalizeControlCode(rawControl);
+    const keyedEntry = normalizedControl
+        ? RUNTIME_CONSTRAINT_DISPLAY_COPY[
+            `${normalizedControl}:${normalizedCode}` as keyof typeof RUNTIME_CONSTRAINT_DISPLAY_COPY
+        ]
+        : undefined;
+    const entry = keyedEntry
+        ?? RUNTIME_CONSTRAINT_DISPLAY_COPY[normalizedCode as keyof typeof RUNTIME_CONSTRAINT_DISPLAY_COPY];
+
+    if (entry) {
+        return {
+            title: entry.title[locale],
+            body: entry.body[locale],
+            fallback: false,
+        };
+    }
+
+    return {
+        title: locale === 'ko' ? '운영 제약 확인 필요' : 'Operating constraint needs review',
+        body: locale === 'ko'
+            ? '사전에 없는 운영 제약이 감지되었습니다. 현재 설정을 확인해 주세요.'
+            : 'An unmapped operating constraint was detected. Please review the current setting.',
+        auxiliaryText: getSourceCodeText([rawControl, rawCode], locale),
+        fallback: true,
+    };
 }
 
 export function getDashboardSensorCopy(locale: AppLocale) {

--- a/src/model_informed_greenhouse_dashboard/backend/app/main.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/main.py
@@ -1702,7 +1702,6 @@ async def start_simulation(req: StartRequest):
 
     # Stop any running simulation for THIS crop first
     if crop_state["simulator"] is not None:
-        import asyncio
 
         logger.info(f"Stopping previous {crop} simulation...")
         crop_state["simulator"].stop()
@@ -1991,7 +1990,6 @@ async def run_all():
             simulator = app_state[crop]["simulator"]
             if not simulator.running:
                 simulator.start()
-                import asyncio
                 # Cancel existing task if any
                 if app_state[crop].get("sim_task") and not app_state[crop]["sim_task"].done():
                      app_state[crop]["sim_task"].cancel()
@@ -2007,7 +2005,6 @@ async def run_all():
 
 async def _run_simulation_task(crop: str):
     """Background task to run simulation for specific crop."""
-    import asyncio
 
     crop_state = app_state[crop]
     simulator = crop_state["simulator"]
@@ -2731,7 +2728,6 @@ async def compute_model_sensitivity(req: ModelSensitivityRequest):
 async def advisor_summary(req: AdvisorSummaryRequest):
     """Return a thin SmartGrow advisor summary over live context plus local knowledge."""
     crop = _validate_crop(req.crop)
-    import asyncio
 
     dashboard_payload = _augment_dashboard_with_knowledge_context(crop, req.dashboard)
     try:
@@ -2798,7 +2794,6 @@ async def advisor_chat(req: AdvisorChatRequest):
     """Return a SmartGrow chat reply with orchestration metadata."""
     crop = _validate_crop(req.crop)
     try:
-        import asyncio
 
         return await asyncio.to_thread(
             build_advisor_chat_response,
@@ -2984,7 +2979,6 @@ async def ai_consult(req: AiConsultRequest):
     """Generate consulting content using OpenAI."""
     crop = _validate_crop(req.crop)
     try:
-        import asyncio
 
         text = await asyncio.to_thread(
             generate_consulting,
@@ -3011,7 +3005,6 @@ async def ai_chat(req: AiChatRequest):
     """Chat endpoint using OpenAI."""
     crop = _validate_crop(req.crop)
     try:
-        import asyncio
 
         text = await asyncio.to_thread(
             generate_chat_reply,
@@ -3146,7 +3139,6 @@ async def get_overview_signal_trends(
     window_hours: int = 72,
 ):
     """Return greenhouse irradiance and model source-sink trend points."""
-    import asyncio
 
     from .services.model_runtime.model_state_store import ModelStateStore
     from .services.model_runtime.scenario_runner import extract_runtime_inputs

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -429,3 +429,20 @@ def test_verify_src001_s0002_r007_a01_status_includes_current_sim_seconds_per_re
     cucumber = response.json()["greenhouses"]["cucumber"]
     assert cucumber["sim_seconds_per_real_second"] == 4321.0
     assert cucumber["step_sim_duration_seconds"] == 600.0
+
+
+def test_main_has_no_function_local_asyncio_import() -> None:
+    """Regression guard for the /api/start UnboundLocalError.
+
+    A function-local `import asyncio` anywhere inside a function makes
+    `asyncio` a local variable for the WHOLE function body, so any use above
+    that line (e.g. the pace_changed_event setup in start_simulation on the
+    fresh-start path) crashes with UnboundLocalError before the import runs.
+    main.py imports asyncio at module scope; no function may shadow it.
+    """
+    import re
+    from pathlib import Path
+
+    source = Path(backend_main.__file__).read_text(encoding="utf-8")
+    shadowing_imports = re.findall(r"^[ \t]+import asyncio\b.*$", source, re.MULTILINE)
+    assert shadowing_imports == []


### PR DESCRIPTION
## Summary
Makes the dashboard grower-friendly: Korean alert copy, two-tier navigation, and panel deduplication.

- Alert copy: `alertItems` no longer renders backend payloads verbatim (`rh_target · humidity_floor_risk`, English constraint sentences); a single Korean display dictionary in `utils/displayCopy.ts` (consolidating three duplicated maps) supplies titles/explanations, with a generalized fallback for unknown codes (raw code demoted to secondary text). Tests fail if snake_case leaks into titles.
- Navigation: the global HOME · DASHBOARD · INSIGHTS · SCENARIOS · KNOWLEDGE · CONTACT nav persists on every screen with only the active category's sub-tabs below it (DASHBOARD → control/rtr/crop-work/resources/alerts; INSIGHTS → trend; …); the flat 10-item strip is gone; URLs unchanged; settings via the header gear.
- Panels: `SimulationRuntimePanel` moved from `/control` to `/settings` (all #131 pacing behavior/tests intact); `/rtr` stripped to RTR-only panels; TodayBoard/ModelRuntimeBridge/AlertRail/DecisionSnapshotGrid deduplicated to canonical homes with no feature loss.

## Validation
Frontend lint 0 / vitest 222 (50 files) / build 0; backend untouched (ruff clean, pytest green). Live-verified on a fresh backend+frontend: global nav persists with scoped sub-tabs on `/control`, `/trend`; Simulation Runtime renders on `/settings` with all six pace presets.

## Risk / rollback
Frontend presentation/composition only; revert restores prior IA. Stacked on #133.

Refs #134
