### PR TITLE
fix: break the chart-vendor chunk cycle that white-screened production

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,11 @@ const reactChunkMarkers = [
   'node_modules/react/',
   'node_modules/react-dom/',
   'node_modules/scheduler/',
+  // Shared React helper used by both app-level vendors and recharts; leaving it
+  // outside react-vendor lets Rollup route it through the entry chunk and form
+  // an entry <-> chart-vendor cycle that evaluates recharts before React is
+  // initialized (the production forwardRef white-screen).
+  'node_modules/react-is/',
 ]
 
 const routerChunkMarkers = [
@@ -40,13 +45,12 @@ const iconChunkMarkers = [
   'node_modules/lucide-react/',
 ]
 
-const chartChunkMarkers = [
-  'node_modules/recharts/',
-  'node_modules/victory-vendor/',
-  'node_modules/d3-',
-  'node_modules/internmap/',
-  'node_modules/clsx/',
-]
+// NOTE: recharts/d3 must NOT be forced into their own chunk. Their satellite
+// dependencies (react-smooth, lodash, victory-vendor helpers, ...) are shared
+// with entry-side modules, so a pinned chart chunk ends up in a mutual import
+// cycle with react-vendor/entry and evaluates before React is initialized —
+// the production "reading 'forwardRef'" white-screen. Rollup's default
+// chunking already keeps chart code inside the lazy route chunks.
 
 // https://vite.dev/config/
 //
@@ -79,10 +83,6 @@ export default defineConfig({
 
           if (iconChunkMarkers.some((marker) => id.includes(marker))) {
             return 'icon-vendor'
-          }
-
-          if (chartChunkMarkers.some((marker) => id.includes(marker))) {
-            return 'chart-vendor'
           }
 
           if (markdownChunkMarkers.some((marker) => id.includes(`node_modules${marker}`))) {


### PR DESCRIPTION
## Summary
Fixes the production white-screen: `vite preview` crashed with `TypeError: reading 'forwardRef'` from the `chart-vendor` chunk while `npm run build` exited 0.

Root cause (verified in the emitted bundles): `manualChunks` pinned recharts/d3/clsx into `chart-vendor`, whose shared satellite deps created a **mutual import cycle** with `react-vendor` (each chunk imported the other), letting the chart chunk evaluate before React initialized. Fix: drop the forced chart chunk (Rollup's default chunking keeps chart code inside the lazy route chunks) and add `react-is` to the react-vendor markers; explanatory comments guard the config.

## Validation
Before: crash reproduced live on `/overview` (blank root, forwardRef TypeError). After: `vite preview` renders `/overview` and `/trend` with zero chunk-init console errors; build 0; lint 0; vitest 222 green. Includes the #131 fresh-start backend hotfix commit (`6a649f7`) in this stack segment.

## Risk / rollback
Bundle-layout only; chunk sizes shift slightly (chart code now in lazy `ChartFrame` chunk). Revert restores the old (broken) chunking. Stacked on #134.

Refs #135
