### PR TITLE
Raise advisor answer quality: quantitative model bridge, pesticide safety gate, corpus integrity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,11 @@ OPENAI_MODEL=gpt-5.4-mini
 # The official KAMIS daily price docs publish `test/test` as the sample values.
 KAMIS_API_KEY=test
 KAMIS_API_ID=test
+
+# Optional: RDA PSIS (농약안전정보시스템) service key from data.go.kr, used to look up
+# authoritative pesticide safe-use standards (PHI / 안전사용기준). Without it the advisor
+# refuses safe-use numbers and points the grower to psis.rda.go.kr rather than guessing.
+# Register at https://www.data.go.kr/data/15059306/openapi.do and paste the DECODED key.
+PSIS_SERVICE_KEY=
+# Optional: override the PSIS endpoint (defaults to the data.go.kr AgriPollutionService).
+PSIS_BASE_URL=

--- a/frontend/src/components/dashboard/ModelScenarioWorkbench.tsx
+++ b/frontend/src/components/dashboard/ModelScenarioWorkbench.tsx
@@ -22,13 +22,17 @@ const MODEL_SCENARIO_CONTROL_KEYS = [
   'screen_close',
 ] as const;
 
-const SENSITIVITY_TARGETS = [
-  'predicted_yield_24h',
-  'predicted_yield_72h',
-  'predicted_yield_7d',
-  'predicted_yield_14d',
-  'source_sink_balance_72h',
-  'energy_cost_72h',
+// `energy_load_index_72h` was called `energy_cost_72h` until 2026-07-17, which read
+// as money in a dropdown that renders raw identifiers. It is a dimensionless index —
+// `horizon_days * (0.75 + energy_rate_delta)`, never multiplied by kWh or a tariff —
+// so its gradient is an index gradient, not ₩/℃. The label says so.
+const SENSITIVITY_TARGETS: readonly { value: string; label: string }[] = [
+  { value: 'predicted_yield_24h', label: 'predicted_yield_24h — 예상 수량 (24h)' },
+  { value: 'predicted_yield_72h', label: 'predicted_yield_72h — 예상 수량 (72h)' },
+  { value: 'predicted_yield_7d', label: 'predicted_yield_7d — 예상 수량 (7d)' },
+  { value: 'predicted_yield_14d', label: 'predicted_yield_14d — 예상 수량 (14d)' },
+  { value: 'source_sink_balance_72h', label: 'source_sink_balance_72h — 소스/싱크 균형 (72h)' },
+  { value: 'energy_load_index_72h', label: 'energy_load_index_72h — 에너지 부하 지수 (무차원, 비용 아님)' },
 ];
 
 function toNumber(value: string): number {
@@ -208,7 +212,7 @@ export default function ModelScenarioWorkbench({ crop }: ModelScenarioWorkbenchP
             <label className="mt-3 block text-xs font-semibold text-[color:var(--sg-text-muted)]">
               <span>{copy.sensitivityTarget}</span>
               <Select className="mt-1" value={target} onChange={(event) => setTarget(event.target.value)} aria-label={copy.sensitivityTarget}>
-                {SENSITIVITY_TARGETS.map((value) => <option key={value} value={value}>{value}</option>)}
+                {SENSITIVITY_TARGETS.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
               </Select>
             </label>
             <p className="mt-3 rounded-[var(--sg-radius-sm)] bg-[color:var(--sg-surface-muted)] p-2 text-xs leading-5 text-[color:var(--sg-text-muted)]">

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,223 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
+    {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd"},
+    {file = "cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f"},
+    {file = "cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e"},
+    {file = "cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479"},
+    {file = "cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458"},
+    {file = "cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b"},
+    {file = "cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a"},
+    {file = "cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384"},
+    {file = "cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a"},
+    {file = "cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2"},
+    {file = "cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512"},
+    {file = "cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326"},
+    {file = "cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd"},
+    {file = "cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb"},
+    {file = "cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94"},
+    {file = "cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629"},
+    {file = "cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6"},
+    {file = "cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853"},
+    {file = "cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9"},
+    {file = "cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
+    {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:253a4a220747e8b5faf57ec320c4f5efb0cef05f647420bf267143ec15dba10a"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68ce9f4d6b26d5ccbf7fd4459bf75f74a0a146677ebba80597df60cbdb20e6f4"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:58150c9f9b9a552505912d182ccdf26f6396fb6094816ceebcbb20eecabaed94"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df7276909358e5635ae203673ab7e509ddd224225a8d6b0790bf13eb2bde1cc5"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c09a49d6cde137258beb3d551994a2927fd35ad5cf96aed573f61bbd67c5f84"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:231ddcbb35e2ff8973e1365db41fe0572662893b99a05deb183b68ad4c0c8bd4"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:920079c3f7456fa213e0829ed2073aaa727fd39d889ead5b4f35d0de5460d04f"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0fa1aec2d32bcc03c8fa0f6f1712caad1adc38509f31142112e5c9daf5b9c833"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ad41ba96094304aa090f5a30cb6e4fb3b3f1c264c523394b4c39bbacc4dc92ba"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:43b9e366a31fdd1c87d0eb08f579b4a82b723ea54338f040d6b4e518a026ea29"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win32.whl", hash = "sha256:93d59d504b230e83c7a843251681959a0b6a9cd76f6e146ce1b8a80eb8739af9"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win_amd64.whl", hash = "sha256:ddf4af30b417d9fe16481e9b81c27ab2a7cde1ff7ba3e85653b02db7d145dc7b"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win_arm64.whl", hash = "sha256:476743fe6dfe14a2da12e3ac79125dc84a3b2cf8094369a47a1529b0cd8549fe"},
+    {file = "charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"},
+    {file = "charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"},
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
@@ -70,6 +287,68 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
+groups = ["main"]
+files = [
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
 name = "distro"
@@ -538,6 +817,25 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "pdfminer-six"
+version = "20260107"
+description = "PDF parser and analyzer"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9"},
+    {file = "pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602"},
+]
+
+[package.dependencies]
+charset-normalizer = ">=2.0.0"
+cryptography = ">=36.0.0"
+
+[package.extras]
+image = ["Pillow"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -552,6 +850,19 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
 
 [[package]]
 name = "pydantic"
@@ -1452,4 +1763,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "8be57f77e98d46726eccb69131c038cd033d695c606858b65dfe163fb82ca32c"
+content-hash = "4888c05bf8469f0ec4bd5c825f506c79cd65223e7ee21974412973adb1838cd2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ dependencies = [
     "httpx>=0.27,<0.28",
     "openai (>=2.30.0,<3.0.0)",
     "pypdf (==5.5.0)",
+    # pdfminer.six (MIT) resolves CID->Unicode from an external table where pypdf
+    # cannot, which recovers the two Japanese 農業技術大系 PDFs and also raises the
+    # Hangul yield on the Korean guides. Chosen over PyMuPDF, whose AGPL/commercial
+    # dual licence would be contagious for a distributed tool.
+    "pdfminer.six (>=20250506)",
 ]
 
 

--- a/src/model_informed_greenhouse_dashboard/backend/app/main.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/main.py
@@ -3687,6 +3687,12 @@ async def compute_rtr_optimizer_sensitivity(req: RTRSensitivityRequest):
         horizon_hours=24,
         sensitivities=sensitivity_payload["sensitivities"],
     )
+    # The canonical "온도 1℃ 올리면 난방비/마디?" answer, admitted and composed: each
+    # ₩ and node derivative passes the admission gate and is rendered with its unit,
+    # validity range, and tariff/area provenance — or refused when untrustworthy.
+    from .services.answer_composer import build_marginal_change_facts
+
+    answer_facts = build_marginal_change_facts(sensitivity_payload)
     return {
         "status": "success",
         "mode": "optimizer",
@@ -3696,6 +3702,8 @@ async def compute_rtr_optimizer_sensitivity(req: RTRSensitivityRequest):
         "target_horizon": optimization_inputs.target_horizon,
         "step_c": req.step_c,
         "sensitivities": stored_rows,
+        "answer_facts": answer_facts,
+        "assumptions": sensitivity_payload.get("assumptions", {}),
         "optimized_targets": optimized_candidate["controls"],
         "area_unit_meta": area_meta,
         "actuator_availability": build_actuator_availability(context.ops_config).as_dict(),

--- a/src/model_informed_greenhouse_dashboard/backend/app/main.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/main.py
@@ -1106,14 +1106,23 @@ def _build_rtr_provisional_state_response(crop: str, greenhouse_id: Optional[str
 
 
 def _get_crop_cost_per_kwh(crop: str) -> float:
+    return _get_crop_cost_per_kwh_with_source(crop)[0]
+
+
+def _get_crop_cost_per_kwh_with_source(crop: str) -> tuple[float, str]:
+    """The tariff and where it came from.
+
+    A ₩ figure computed from the ₩120/kWh placeholder must not be presented to a
+    grower as their own cost, so the caller has to be able to tell the difference.
+    """
     decision_service = app_state[crop].get("decision")
     settings_payload = getattr(decision_service, "settings", None) if decision_service else None
-    if isinstance(settings_payload, dict):
+    if isinstance(settings_payload, dict) and "cost_per_kwh" in settings_payload:
         try:
-            return float(settings_payload.get("cost_per_kwh", 120.0))
+            return (float(settings_payload["cost_per_kwh"]), "settings")
         except (TypeError, ValueError):
-            return 120.0
-    return 120.0
+            return (120.0, "default")
+    return (120.0, "default")
 
 
 def _build_rtr_request_bundle(req_payload: Dict[str, Any]):
@@ -1139,6 +1148,7 @@ def _build_rtr_request_bundle(req_payload: Dict[str, Any]):
     optimization_inputs = build_service_inputs(req_payload, greenhouse_id=greenhouse_id)
     profiles_payload = load_rtr_profiles()
     recent_events = store.list_work_events(greenhouse_id, crop, limit=12)
+    cost_per_kwh, cost_per_kwh_source = _get_crop_cost_per_kwh_with_source(crop)
     context = build_internal_model_context(
         snapshot_record=snapshot_record,
         crop_state=app_state[crop],
@@ -1146,7 +1156,9 @@ def _build_rtr_request_bundle(req_payload: Dict[str, Any]):
         profiles_payload=profiles_payload,
         recent_events=recent_events,
         actual_area_m2=float(area_meta["actual_area_m2"] or greenhouse_config["greenhouse"]["area_m2"]),
-        cost_per_kwh=_get_crop_cost_per_kwh(crop),
+        cost_per_kwh=cost_per_kwh,
+        cost_per_kwh_source=cost_per_kwh_source,
+        actual_area_m2_source=("settings" if area_meta["actual_area_m2"] else "default"),
     )
     return crop, store, greenhouse_id, snapshot_record, profiles_payload, area_meta, optimization_inputs, context
 
@@ -3345,7 +3357,9 @@ async def get_rtr_state(crop: str, greenhouse_id: Optional[str] = None, snapshot
         profiles_payload=load_rtr_profiles(),
         recent_events=store.list_work_events(resolved_greenhouse_id, normalized_crop, limit=12),
         actual_area_m2=float(area_meta["actual_area_m2"] or greenhouse_config["greenhouse"]["area_m2"]),
-        cost_per_kwh=_get_crop_cost_per_kwh(normalized_crop),
+        cost_per_kwh=_get_crop_cost_per_kwh_with_source(normalized_crop)[0],
+        cost_per_kwh_source=_get_crop_cost_per_kwh_with_source(normalized_crop)[1],
+        actual_area_m2_source=("settings" if area_meta["actual_area_m2"] else "default"),
     )
     optimizer_inputs = _build_rtr_request_bundle(
         {

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_context_builder.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_context_builder.py
@@ -7,10 +7,20 @@ from typing import Any, Mapping, Sequence
 from .knowledge_database import query_knowledge_database
 
 
-_MAX_CHAT_RESULTS = 3
+#: Evidence budget for a chat answer.
+#:
+#: Until 2026-07-17 this was 3 results x 240 chars = **720 characters** of unique
+#: literature per answer, taken from chunks stored at 1,200 chars — i.e. ~80% of
+#: every retrieved chunk was discarded before the model ever saw it, and an expert
+#: agronomy answer was expected from roughly one page of pre-truncated prose.
+#:
+#: A 1,200-char excerpt is a complete chunk: `knowledge_database._PDF_CHUNK_CHARS`
+#: builds chunks on paragraph/sentence boundaries at that size, so this passes whole
+#: passages through instead of cutting them mid-sentence.
+_MAX_CHAT_RESULTS = 6
 _MAX_SUMMARY_RESULTS = 2
 _MAX_SUMMARY_QUERIES = 3
-_MAX_EXCERPT_CHARS = 240
+_MAX_EXCERPT_CHARS = 1200
 _TAB_DOMAIN_MAP = {
     "environment": ("environment_control",),
     "physiology": ("crop_physiology",),

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
@@ -16,6 +16,7 @@ from .advisor_context_builder import (
     build_summary_advisor_context,
     build_tab_advisor_context,
 )
+from .answer_admission import grounding_decision
 from .advisory_api import (
     build_nutrient_correction_response,
     build_nutrient_recommendation_response,
@@ -259,16 +260,26 @@ def _inject_advisor_retrieval_context(
     dashboard: dict[str, Any],
     retrieval_context: dict[str, Any],
 ) -> dict[str, Any]:
-    if retrieval_context.get("status") != "ready":
-        return dashboard
+    # Always record the grounding decision, even when retrieval found nothing. The
+    # old early-return dropped the whole context on a miss, so a zero-evidence answer
+    # was indistinguishable from a grounded one — the silent-failure defect the
+    # council flagged. A GROUNDED answer and a NO_MATCH answer must look different.
+    decision = grounding_decision(retrieval_context)
 
-    llm_context = retrieval_context.get("llm_context")
-    if not llm_context:
-        return dashboard
+    llm_context = None
+    if retrieval_context.get("status") == "ready":
+        candidate = retrieval_context.get("llm_context")
+        # Only attach the context when it actually carries evidence; an empty card
+        # list is a NO_MATCH, and attaching it would put a hollow context next to a
+        # NO_MATCH decision.
+        if isinstance(candidate, dict) and candidate.get("evidence_cards"):
+            llm_context = candidate
 
     dashboard_payload = deepcopy(dashboard)
     knowledge_payload = dict(dashboard_payload.get("knowledge") or {})
-    knowledge_payload["advisor_retrieval_context"] = llm_context
+    if llm_context:
+        knowledge_payload["advisor_retrieval_context"] = llm_context
+    knowledge_payload["grounding_decision"] = decision.value
     dashboard_payload["knowledge"] = knowledge_payload
     return dashboard_payload
 

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
@@ -465,6 +465,62 @@ def _format_signed_delta(value: Any, digits: int = 3) -> str:
     return f"{numeric:+.{digits}f}"
 
 
+#: Below this the requested and computed deltas are the same number.
+_DELTA_EXACT_MATCH_TOLERANCE = 1e-6
+
+
+def _build_out_of_range_answer_focus(
+    *,
+    family: dict[str, Any],
+    requested_delta: float,
+    max_supported_delta: float,
+    language: str,
+) -> dict[str, Any]:
+    """A what-if the model cannot answer, rendered without any numbers.
+
+    The bounded scenario is only solved on a small ladder of steps around the
+    current state. Asking for a step beyond it is not a harder question, it is a
+    different one, and the model has no answer to it.
+    """
+    label = str(family.get("label") or family.get("control") or "control")
+    unit = str(family.get("unit") or "")
+    if language.lower().startswith("en"):
+        summary = (
+            f"{label} {requested_delta:+g}{unit} is outside the range the model solves "
+            f"(±{max_supported_delta:g}{unit} around the current setpoint), so there is no "
+            f"calculated effect for it. Ask within ±{max_supported_delta:g}{unit}, or change "
+            f"the setpoint and let the model re-solve around the new state."
+        )
+    else:
+        summary = (
+            f"{label} {requested_delta:+g}{unit}는 모델이 계산하는 범위(현재 설정 기준 "
+            f"±{max_supported_delta:g}{unit}) 밖이라 계산된 효과가 없습니다. "
+            f"±{max_supported_delta:g}{unit} 안에서 물어보시거나, 설정을 바꾼 뒤 새 상태에서 "
+            f"다시 계산하도록 하세요."
+        )
+    return {
+        "kind": "model_what_if_out_of_range",
+        "computed_by": "process_model_bounded_scenario",
+        "control": family.get("control"),
+        "label": label,
+        "requested_delta": requested_delta,
+        "matched_delta": None,
+        "max_supported_delta": max_supported_delta,
+        "unit": family.get("unit"),
+        "action": None,
+        "summary": summary,
+        # No effects: an out-of-range question has no calculated answer, and a
+        # nearby step's numbers are not an approximation of it.
+        "effects": {},
+        "confidence": 0.0,
+        "risk_flags": ["requested_delta_out_of_model_range"],
+        "violated_constraints": [],
+        "precision_mode": family.get("precision_mode"),
+        "matched_user_request": False,
+        "admissible": False,
+    }
+
+
 def _build_runtime_answer_focus(
     *,
     messages: Optional[list[dict[str, str]]],
@@ -498,6 +554,20 @@ def _build_runtime_answer_focus(
         if requested_delta is None:
             step = family.get("recommended_step")
         else:
+            # A nearest-neighbour match with no bound is a silent substitution: a
+            # grower asking "+5℃?" was answered with the +0.9℃ result, in fluent
+            # Korean, with the prompt forbidding any mention that a swap happened.
+            # Refuse instead of answering a question nobody asked.
+            max_supported_delta = max(
+                abs(float(item.get("applied_delta", 0.0))) for item in steps
+            )
+            if abs(requested_delta) > max_supported_delta:
+                return _build_out_of_range_answer_focus(
+                    family=family,
+                    requested_delta=requested_delta,
+                    max_supported_delta=max_supported_delta,
+                    language=language,
+                )
             step = min(
                 steps,
                 key=lambda item: abs(float(item.get("applied_delta", 0.0)) - requested_delta),
@@ -507,6 +577,14 @@ def _build_runtime_answer_focus(
 
         label = str(family.get("label") or family.get("control") or "control")
         step_label = str(step.get("step_label") or "")
+        matched_delta = _coerce_float(step.get("applied_delta"))
+        # In range, but the ladder is discrete: if the solved step is not the step
+        # that was asked for, the answer is about a different change and must say so.
+        substituted = (
+            requested_delta is not None
+            and matched_delta is not None
+            and abs(matched_delta - requested_delta) > _DELTA_EXACT_MATCH_TOLERANCE
+        )
         effects = {
             "yield_delta_24h": step.get("yield_delta_24h"),
             "yield_delta_72h": step.get("yield_delta_72h"),
@@ -520,21 +598,38 @@ def _build_runtime_answer_focus(
             "humidity_penalty_delta": step.get("humidity_penalty_delta"),
             "disease_penalty_delta": step.get("disease_penalty_delta"),
         }
+        unit = str(family.get("unit") or "")
         if language.lower().startswith("en"):
+            substitution_note = (
+                f" Note: {requested_delta:+g}{unit} was asked for, but the model solves a "
+                f"discrete ladder — these numbers are for {matched_delta:+g}{unit} and must be "
+                f"presented as such, not as the answer to {requested_delta:+g}{unit}."
+                if substituted
+                else ""
+            )
             summary = (
                 f"{label} {step_label} was calculated by the process-model bounded scenario as "
                 f"14d yield {_format_signed_delta(effects['yield_delta_14d'])}, "
                 f"72h canopy assimilation {_format_signed_delta(effects['canopy_delta_72h'])}, "
                 f"source/sink balance {_format_signed_delta(effects['source_sink_balance_delta'])}, "
                 f"and energy {_format_signed_delta(effects['energy_delta'])}."
+                f"{substitution_note}"
             )
         else:
+            substitution_note = (
+                f" 주의: 요청은 {requested_delta:+g}{unit}였지만 모델은 정해진 단계만 계산합니다 — "
+                f"이 숫자는 {matched_delta:+g}{unit} 기준이므로 {requested_delta:+g}{unit}의 답인 것처럼 "
+                f"말하지 말고 {matched_delta:+g}{unit} 기준임을 밝히세요."
+                if substituted
+                else ""
+            )
             summary = (
                 f"{label} {step_label} 조정은 process-model bounded scenario에서 "
                 f"14일 예상 수량 {_format_signed_delta(effects['yield_delta_14d'])}, "
                 f"72시간 캐노피 동화량 {_format_signed_delta(effects['canopy_delta_72h'])}, "
                 f"소스-싱크 균형 {_format_signed_delta(effects['source_sink_balance_delta'])}, "
                 f"에너지 {_format_signed_delta(effects['energy_delta'])}로 계산됐습니다."
+                f"{substitution_note}"
             )
         return {
             "kind": "model_what_if",
@@ -549,11 +644,18 @@ def _build_runtime_answer_focus(
             "summary": summary,
             "effects": effects,
             "confidence": step.get("confidence"),
-            "risk_flags": step.get("risk_flags", []),
+            "risk_flags": [
+                *step.get("risk_flags", []),
+                *(["computed_delta_differs_from_request"] if substituted else []),
+            ],
             "violated_constraints": step.get("violated_constraints", []),
             "operator_summary": family.get("operator_summary", {}),
             "precision_mode": family.get("precision_mode"),
-            "matched_user_request": requested_delta is not None,
+            # True only when the numbers are for the delta the grower actually
+            # asked about — not merely because a request was parsed.
+            "matched_user_request": requested_delta is not None and not substituted,
+            "delta_substituted": substituted,
+            "admissible": True,
         }
 
     return None

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/advisor_orchestration.py
@@ -24,6 +24,8 @@ from .advisory_api import (
 )
 from .decision import DecisionSupport
 from .knowledge_catalog import build_knowledge_catalog
+from .knowledge_query_router import route_knowledge_query
+from .pesticide_safety import asks_for_safe_use_number, safe_use_refusal
 from .model_runtime.constraint_engine import CONTROL_SPECS
 from .model_runtime.model_state_store import ModelStateStore
 from .model_runtime.scenario_runner import (
@@ -5152,6 +5154,58 @@ def prime_advisor_chat_runtime(
     }
 
 
+def _build_chat_pesticide_context(*, crop: str, question: str | None) -> dict[str, Any] | None:
+    """Deterministic pesticide recommendation for a free-form chat question.
+
+    Returns None when the question is not a pesticide question, so the normal chat
+    path is untouched for everything else.
+    """
+    if not question:
+        return None
+    route = route_knowledge_query(question)
+    if route.get("intent") != "disease_pest":
+        return None
+    try:
+        payload = build_pesticide_recommendation_response(
+            crop=crop,
+            target=question,
+            limit=5,
+        )
+    except Exception:
+        return None
+    if payload.get("status") not in {"success", "ok"}:
+        return None
+    return payload
+
+
+def _inject_pesticide_recommendation_context(
+    dashboard: dict[str, Any],
+    pesticide_payload: dict[str, Any],
+) -> dict[str, Any]:
+    dashboard_payload = deepcopy(dashboard)
+    knowledge_payload = dict(dashboard_payload.get("knowledge") or {})
+    knowledge_payload["deterministic_pesticide"] = {
+        "source": "recommend_pesticides",
+        "note": (
+            "등록 상태·계통(MoA)·교호방제·혼용 주의는 이 결정론 결과에서만 답하세요. "
+            "안전사용기준(수확 전 사용일수·사용 횟수·희석배수)은 여기에 없으니 숫자를 지어내지 마세요."
+        ),
+        "recommendation": pesticide_payload,
+    }
+    dashboard_payload["knowledge"] = knowledge_payload
+    return dashboard_payload
+
+
+def _last_user_chat_message(messages: list[dict[str, str]] | None) -> str | None:
+    for message in reversed(messages or []):
+        if str(message.get("role") or "user").strip().lower() != "user":
+            continue
+        content = str(message.get("content") or "").strip()
+        if content:
+            return content
+    return None
+
+
 def build_advisor_chat_response(
     *,
     crop: str,
@@ -5162,6 +5216,26 @@ def build_advisor_chat_response(
     dashboard_payload = dashboard or {}
     catalog_payload = build_knowledge_catalog(crop)
     advisory_surfaces = catalog_payload.get("advisory_surfaces", {})
+
+    # A pesticide safe-use number (PHI, application count, dilution) is legally
+    # binding and the local schema has no field for it. Refuse it deterministically
+    # before any LLM call, rather than letting the model parse it out of free text
+    # or invent it. This is a hard gate, not a prompt instruction.
+    last_user = _last_user_chat_message(messages)
+    if last_user and asks_for_safe_use_number(last_user):
+        refusal = safe_use_refusal(language=language)
+        return {
+            "status": "success",
+            "family": "advisor_chat",
+            "crop": crop,
+            "text": refusal["message"],
+            "machine_payload": {
+                "answer_gate": "pesticide_safe_use_refusal",
+                "authoritative_sources": refusal["authoritative_sources"],
+                "reason": refusal["reason"],
+            },
+        }
+
     retrieval_context = build_chat_advisor_context(
         crop=crop,
         messages=messages,
@@ -5177,6 +5251,16 @@ def build_advisor_chat_response(
         _inject_advisor_retrieval_context(dashboard_payload, retrieval_context),
         model_runtime,
     )
+    # A free-form pesticide question (not a PHI number, which was refused above) must
+    # be answered from the deterministic recommender — registration status, MoA,
+    # rotation, manual-review gate — not free-written. The tab path already uses it;
+    # chat bypassed it. Inject its result so the model narrates a governed answer.
+    pesticide_context = _build_chat_pesticide_context(crop=crop, question=last_user)
+    if pesticide_context is not None:
+        llm_dashboard = _inject_pesticide_recommendation_context(
+            llm_dashboard, pesticide_context
+        )
+
     # Natural conversation: return the model's reply verbatim, with no machine
     # answer-focus prefix and no structured card parsing. The model_runtime and
     # retrieval context stay in machine_payload for internal use, but the visible

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/answer_admission.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/answer_admission.py
@@ -1,0 +1,274 @@
+"""Answer admission: a number reaches the grower only if it earns it.
+
+The advisor must never state a confident wrong number, because a grower acts on it.
+The failure the council found is that the LLM owns the numbers: it is handed a JSON
+dashboard and free-writes prose, so an untrustworthy derivative (``direction_conflict``,
+``scenario_alignment=false``), a stale figure, or a zero-evidence retrieval is laundered
+into fluent, confident Korean.
+
+This module inverts that. A model-derived number is wrapped in a typed :class:`AnswerFact`
+and passed through admission rules **before** it can be rendered. The dangerous path is
+structurally closed, not merely discouraged by a prompt: an inadmissible fact carries no
+value, so a renderer has nothing to print.
+
+The design choice — deterministic composition, not OpenAI tool calling — is deliberate.
+Tool calling makes the truth of a number contingent on the model choosing to call,
+choosing correctly, and not re-rendering the result. Here the engine owns the number and
+the LLM only narrates a fact that has already been admitted or refused.
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/improvement_spec.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class AdmissionStatus(str, Enum):
+    """Whether a fact may be rendered, and if not, why."""
+
+    ADMITTED = "ADMITTED"
+    DIRECTION_CONFLICT = "DIRECTION_CONFLICT"
+    NONLINEAR = "NONLINEAR"
+    OUT_OF_RANGE = "OUT_OF_RANGE"
+    CLAMPED = "CLAMPED"
+    LOW_CONFIDENCE = "LOW_CONFIDENCE"
+    MISSING_VALUE = "MISSING_VALUE"
+    MISSING_PROVENANCE = "MISSING_PROVENANCE"
+
+
+class GroundingDecision(str, Enum):
+    """The retrieval state behind a literature-grounded answer."""
+
+    GROUNDED = "GROUNDED"
+    NO_MATCH = "NO_MATCH"
+    SOURCE_UNAVAILABLE = "SOURCE_UNAVAILABLE"
+    SOURCE_STALE = "SOURCE_STALE"
+    SOURCE_QUARANTINED = "SOURCE_QUARANTINED"
+
+
+#: Statuses that permit a number to be rendered.
+_ADMITTED = frozenset({AdmissionStatus.ADMITTED})
+
+
+@dataclass(frozen=True)
+class AnswerFact:
+    """A single model-derived number and everything needed to render it honestly.
+
+    ``value`` is None whenever ``status`` is not ADMITTED: an inadmissible fact must
+    not carry a number a careless renderer could reach for.
+    """
+
+    quantity: str
+    status: AdmissionStatus
+    value: float | None
+    unit: str | None
+    control_scope: str | None = None
+    perturbation: float | None = None
+    validity: Mapping[str, Any] | None = None
+    provenance: Mapping[str, Any] | None = None
+    reason: str | None = None
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def admissible(self) -> bool:
+        return self.status in _ADMITTED and self.value is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "quantity": self.quantity,
+            "status": self.status.value,
+            "admissible": self.admissible,
+            "value": self.value,
+            "unit": self.unit,
+            "control_scope": self.control_scope,
+            "perturbation": self.perturbation,
+            "validity": dict(self.validity) if self.validity else None,
+            "provenance": dict(self.provenance) if self.provenance else None,
+            "reason": self.reason,
+            "diagnostics": dict(self.diagnostics),
+        }
+
+
+def _relative_disagreement(a: float, b: float) -> float:
+    scale = max(abs(a), abs(b), 1e-9)
+    return abs(a - b) / scale
+
+
+def admit_sensitivity(
+    row: Mapping[str, Any],
+    *,
+    quantity: str,
+    provenance: Mapping[str, Any] | None = None,
+    min_confidence: float = 0.4,
+    require_provenance: bool = False,
+) -> AnswerFact:
+    """Admit or refuse a single sensitivity row from the sensitivity engine.
+
+    The admission rules, in order (any failing rule is fatal and no number is
+    emitted):
+
+    1. the row must actually carry a value and a unit;
+    2. ``scenario_alignment`` must hold — the model's own signal that the ± probes
+       agree on direction. When it is false the model is saying "do not trust this";
+    3. ``nonlinearity_hint`` must not be ``direction_conflict`` (fatal) and, if
+       ``nonlinear``, the derivative is withdrawn (the local slope does not describe
+       the response). A ``mild_nonlinear`` probe asymmetry is recorded, not refused;
+    4. ``local_confidence`` must clear ``min_confidence``;
+    5. when ``require_provenance`` is set (currency answers), the tariff/area
+       provenance must be present.
+    """
+    diagnostics = {
+        "scenario_alignment": row.get("scenario_alignment"),
+        "nonlinearity_hint": row.get("nonlinearity_hint"),
+        "local_confidence": row.get("local_confidence"),
+        "direction": row.get("direction"),
+    }
+    common = {
+        "quantity": quantity,
+        "unit": row.get("unit"),
+        "control_scope": row.get("control"),
+        "perturbation": row.get("perturbation_size"),
+        "validity": row.get("trust_region"),
+        "provenance": provenance,
+        "diagnostics": diagnostics,
+    }
+
+    def refuse(status: AdmissionStatus, reason: str) -> AnswerFact:
+        return AnswerFact(status=status, value=None, reason=reason, **common)
+
+    derivative = row.get("derivative")
+    if derivative is None or row.get("unit") is None:
+        return refuse(AdmissionStatus.MISSING_VALUE, "no derivative or unit on the row")
+
+    hint = str(row.get("nonlinearity_hint") or "")
+    if hint == "direction_conflict":
+        return refuse(
+            AdmissionStatus.DIRECTION_CONFLICT,
+            "the ± probes disagree on direction; the derivative is not usable as a "
+            "basis for a control change",
+        )
+
+    if row.get("scenario_alignment") is False:
+        return refuse(
+            AdmissionStatus.DIRECTION_CONFLICT,
+            "scenario_alignment is false; the model does not trust this derivative",
+        )
+
+    if hint == "nonlinear":
+        return refuse(
+            AdmissionStatus.NONLINEAR,
+            "the response is nonlinear over the step; a single slope does not "
+            "describe it, use a bounded scenario at the exact delta instead",
+        )
+
+    # A "mild_nonlinear" asymmetry between the ± probes is tolerated but recorded, so
+    # a caller can widen the caveat. Anything sharper was already refused above.
+    positive = row.get("positive_response")
+    negative = row.get("negative_response")
+    if positive is not None and negative is not None:
+        diagnostics["probe_asymmetry"] = round(
+            _relative_disagreement(float(positive), float(negative)), 6
+        )
+
+    confidence = row.get("local_confidence")
+    if confidence is not None and float(confidence) < min_confidence:
+        return refuse(
+            AdmissionStatus.LOW_CONFIDENCE,
+            f"local_confidence {float(confidence):.2f} is below the {min_confidence:.2f} bar",
+        )
+
+    if require_provenance and not provenance:
+        return refuse(
+            AdmissionStatus.MISSING_PROVENANCE,
+            "a currency figure needs its tariff and area provenance",
+        )
+
+    return AnswerFact(
+        status=AdmissionStatus.ADMITTED,
+        value=round(float(derivative), 6),
+        reason=None,
+        **common,
+    )
+
+
+def admit_rtr_sensitivity_row(
+    row: Mapping[str, Any],
+    *,
+    assumptions: Mapping[str, Any] | None = None,
+    min_confidence: float = 0.0,
+) -> AnswerFact:
+    """Admit an RTR sensitivity row (heating ₩/℃, node rate, …).
+
+    RTR rows use `scenario_alignment` but do not carry a `nonlinearity_hint` or
+    `local_confidence`, so those checks are skipped; the currency rows require the
+    tariff/area provenance to be present.
+    """
+    quantity = str(row.get("target") or "")
+    is_currency = "krw" in quantity.lower() or "krw" in str(row.get("unit") or "").lower()
+    provenance = None
+    if assumptions is not None:
+        provenance = {
+            "cost_per_kwh": assumptions.get("cost_per_kwh"),
+            "cost_per_kwh_source": assumptions.get("cost_per_kwh_source"),
+            "area_m2": assumptions.get("actual_area_m2"),
+            "area_source": assumptions.get("actual_area_m2_source"),
+        }
+
+    diagnostics = {
+        "scenario_alignment": row.get("scenario_alignment"),
+        "direction": row.get("direction"),
+    }
+    common = {
+        "quantity": quantity,
+        "unit": row.get("unit"),
+        "control_scope": row.get("control"),
+        "perturbation": row.get("perturbation_size"),
+        "validity": row.get("trust_region"),
+        "provenance": provenance,
+        "diagnostics": diagnostics,
+    }
+
+    if row.get("derivative") is None or row.get("unit") is None:
+        return AnswerFact(
+            status=AdmissionStatus.MISSING_VALUE, value=None,
+            reason="no derivative or unit on the row", **common,
+        )
+    if row.get("scenario_alignment") is False:
+        return AnswerFact(
+            status=AdmissionStatus.DIRECTION_CONFLICT, value=None,
+            reason="scenario_alignment is false; the model does not trust this derivative",
+            **common,
+        )
+    if is_currency and not provenance:
+        return AnswerFact(
+            status=AdmissionStatus.MISSING_PROVENANCE, value=None,
+            reason="a currency figure needs its tariff and area provenance", **common,
+        )
+
+    return AnswerFact(
+        status=AdmissionStatus.ADMITTED,
+        value=round(float(row["derivative"]), 6),
+        reason=None,
+        **common,
+    )
+
+
+def grounding_decision(retrieval_context: Mapping[str, Any] | None) -> GroundingDecision:
+    """Classify a retrieval result into a grounding state for the envelope."""
+    if not isinstance(retrieval_context, Mapping):
+        return GroundingDecision.NO_MATCH
+    status = str(retrieval_context.get("status") or "").lower()
+    if status in {"retrieval_unavailable", "database_missing"}:
+        return GroundingDecision.SOURCE_UNAVAILABLE
+    cards = retrieval_context.get("evidence_cards")
+    if isinstance(cards, list) and cards:
+        return GroundingDecision.GROUNDED
+    llm_context = retrieval_context.get("llm_context")
+    if isinstance(llm_context, Mapping):
+        cards = llm_context.get("evidence_cards")
+        if isinstance(cards, list) and cards:
+            return GroundingDecision.GROUNDED
+    return GroundingDecision.NO_MATCH

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/answer_admission.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/answer_admission.py
@@ -221,6 +221,12 @@ def admit_rtr_sensitivity_row(
         "scenario_alignment": row.get("scenario_alignment"),
         "direction": row.get("direction"),
     }
+    # Preserve the whole-house total (per-m² derivative x area) so the composer can
+    # answer "how much for MY greenhouse" rather than a per-m² figure.
+    if row.get("derivative_total") is not None:
+        diagnostics["derivative_total"] = row.get("derivative_total")
+        diagnostics["unit_total"] = row.get("unit_total")
+        diagnostics["area_m2"] = row.get("area_m2")
     common = {
         "quantity": quantity,
         "unit": row.get("unit"),

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/answer_composer.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/answer_composer.py
@@ -12,9 +12,9 @@ not reachable from here — there is no number to print.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Any, Iterable, Mapping
 
-from .answer_admission import AdmissionStatus, AnswerFact
+from .answer_admission import AdmissionStatus, AnswerFact, admit_rtr_sensitivity_row
 
 
 def _format_value(value: float, unit: str | None) -> str:
@@ -39,17 +39,23 @@ def _validity_phrase(fact: AnswerFact) -> str:
 
 def _provenance_phrase(fact: AnswerFact) -> str:
     provenance = fact.provenance or {}
+    unit = str(fact.unit or "")
     parts: list[str] = []
-    tariff = provenance.get("cost_per_kwh")
-    if tariff is not None:
-        source = provenance.get("cost_per_kwh_source")
-        note = "추정 기본값" if source == "default" else "설정값"
-        parts.append(f"요금 {tariff:g}원/kWh({note})")
-    area = provenance.get("area_m2")
-    if area is not None:
-        source = provenance.get("area_source")
-        note = "추정 기본값" if source == "default" else "설정값"
-        parts.append(f"면적 {area:g}㎡({note})")
+    # A tariff is only an assumption for a currency figure; a node rate does not
+    # depend on it, so do not attach it there.
+    if "KRW" in unit:
+        tariff = provenance.get("cost_per_kwh")
+        if tariff is not None:
+            source = provenance.get("cost_per_kwh_source")
+            note = "추정 기본값" if source == "default" else "설정값"
+            parts.append(f"요금 {tariff:g}원/kWh({note})")
+    # Area matters whenever a whole-house total is shown.
+    if fact.diagnostics.get("derivative_total") is not None:
+        area = provenance.get("area_m2")
+        if area is not None:
+            source = provenance.get("area_source")
+            note = "추정 기본값" if source == "default" else "설정값"
+            parts.append(f"면적 {area:g}㎡({note})")
     return f" [{', '.join(parts)}]" if parts else ""
 
 
@@ -77,11 +83,72 @@ def compose_fact_sentence(fact: AnswerFact) -> str:
         return f"{label} {fact.quantity}: {why}{detail}."
 
     magnitude = _format_value(fact.value, fact.unit)
-    per = f"/{fact.perturbation:g}단위" if fact.perturbation else ""
+
+    # For a currency figure, lead with the whole-house total per 1°C — the number a
+    # grower can act on — rather than the per-m² gradient. The derivative is already
+    # per-°C, so no "per step" suffix is appended (that would misread the FD step as
+    # a divisor).
+    total = fact.diagnostics.get("derivative_total")
+    unit_total = str(fact.diagnostics.get("unit_total") or "")
+    if total is not None and "KRW" in unit_total:
+        # KRW/m2/day/°C x area -> KRW/day/°C: "1°C 올리면 하루 약 N원".
+        per_c = f"1°C당 하루 약 {float(total):,.0f} 원 (온실 전체)"
+        return (
+            f"{label} {fact.quantity}: {per_c}, 즉 {magnitude}"
+            f"{_validity_phrase(fact)}{_provenance_phrase(fact)}."
+        )
+
     return (
-        f"{label} {fact.quantity}: {magnitude}{per}"
+        f"{label} {fact.quantity}: {magnitude} (1°C당)"
         f"{_validity_phrase(fact)}{_provenance_phrase(fact)}."
     )
+
+
+#: The RTR sensitivity targets that answer the canonical marginal-change question,
+#: mapped to the human quantity name the composer renders.
+_MARGINAL_CHANGE_TARGETS = {
+    "heating_energy_cost_krw": "난방비 변화",
+    "cooling_energy_cost_krw": "냉방비 변화",
+    "total_energy_cost_krw": "에너지 비용 변화",
+    "node_rate_day": "마디 발생속도 변화",
+}
+
+
+def build_marginal_change_facts(sensitivity_payload: Mapping[str, Any]) -> dict:
+    """Admit and compose the RTR sensitivity rows into the ₩/℃ and node/℃ answer.
+
+    This is where "온도를 1℃ 올리면 난방비가 얼마나, 마디는 얼마나?" becomes a set of
+    admitted facts with units, a validity range, and tariff/area provenance — or an
+    explicit refusal when the model does not trust the derivative. It is the join of
+    Phase 1 (the ₩/node derivatives) and Phase 2 (admission + composition).
+    """
+    rows = sensitivity_payload.get("sensitivities") or []
+    assumptions = sensitivity_payload.get("assumptions") or {}
+
+    facts: list[AnswerFact] = []
+    for row in rows:
+        target = str(row.get("target") or "")
+        quantity = _MARGINAL_CHANGE_TARGETS.get(target)
+        if quantity is None:
+            continue
+        fact = admit_rtr_sensitivity_row(row, assumptions=assumptions)
+        # Relabel with the human quantity while keeping the machine target as scope.
+        facts.append(
+            AnswerFact(
+                quantity=quantity,
+                status=fact.status,
+                value=fact.value,
+                unit=fact.unit,
+                control_scope=fact.control_scope,
+                perturbation=fact.perturbation,
+                validity=fact.validity,
+                provenance=fact.provenance,
+                reason=fact.reason,
+                diagnostics={**fact.diagnostics, "target": target},
+            )
+        )
+
+    return compose_answer_facts_block(facts)
 
 
 def compose_answer_facts_block(facts: Iterable[AnswerFact]) -> dict:

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/answer_composer.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/answer_composer.py
@@ -1,0 +1,109 @@
+"""Deterministic rendering of admitted facts.
+
+The composer owns every number and every unit. The LLM's job downstream is to
+narrate the sentence this produces, not to compute, adjust, or invent a figure. An
+inadmissible fact renders as an explicit refusal, never as a nearby number dressed up
+as the answer.
+
+This is the render half of the admission contract in :mod:`answer_admission`: because an
+inadmissible :class:`AnswerFact` carries no value, the "confident wrong number" path is
+not reachable from here — there is no number to print.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .answer_admission import AdmissionStatus, AnswerFact
+
+
+def _format_value(value: float, unit: str | None) -> str:
+    # Currency reads better as an integer; physiology rates need decimals.
+    if unit and "KRW" in unit:
+        magnitude = f"{value:,.0f}" if abs(value) >= 1 else f"{value:.4f}"
+    elif abs(value) >= 100:
+        magnitude = f"{value:,.1f}"
+    else:
+        magnitude = f"{value:.4f}".rstrip("0").rstrip(".")
+    return f"{magnitude} {unit}".strip() if unit else magnitude
+
+
+def _validity_phrase(fact: AnswerFact) -> str:
+    validity = fact.validity or {}
+    low = validity.get("low")
+    high = validity.get("high")
+    if low is None or high is None:
+        return ""
+    return f" (유효 범위 {low:g}~{high:g})"
+
+
+def _provenance_phrase(fact: AnswerFact) -> str:
+    provenance = fact.provenance or {}
+    parts: list[str] = []
+    tariff = provenance.get("cost_per_kwh")
+    if tariff is not None:
+        source = provenance.get("cost_per_kwh_source")
+        note = "추정 기본값" if source == "default" else "설정값"
+        parts.append(f"요금 {tariff:g}원/kWh({note})")
+    area = provenance.get("area_m2")
+    if area is not None:
+        source = provenance.get("area_source")
+        note = "추정 기본값" if source == "default" else "설정값"
+        parts.append(f"면적 {area:g}㎡({note})")
+    return f" [{', '.join(parts)}]" if parts else ""
+
+
+_REFUSAL_PHRASES = {
+    AdmissionStatus.DIRECTION_CONFLICT: "방향을 신뢰할 수 없어 제어 근거로 쓸 수 없습니다",
+    AdmissionStatus.NONLINEAR: "이 구간에서는 비선형이라 단일 기울기로 답할 수 없습니다",
+    AdmissionStatus.OUT_OF_RANGE: "모델이 계산하는 범위를 벗어났습니다",
+    AdmissionStatus.CLAMPED: "실제 반응이 모델 관측 범위를 넘어 정확한 값을 낼 수 없습니다",
+    AdmissionStatus.LOW_CONFIDENCE: "신뢰도가 낮아 숫자로 제시하지 않습니다",
+    AdmissionStatus.MISSING_VALUE: "계산된 값이 없습니다",
+    AdmissionStatus.MISSING_PROVENANCE: "요금·면적 정보가 없어 비용을 계산할 수 없습니다",
+}
+
+
+def compose_fact_sentence(fact: AnswerFact) -> str:
+    """One deterministic Korean sentence stating a fact or refusing it.
+
+    The number, unit, validity range and provenance are all fixed here; nothing
+    downstream is permitted to change them.
+    """
+    label = fact.control_scope or fact.quantity
+    if not fact.admissible or fact.value is None:
+        why = _REFUSAL_PHRASES.get(fact.status, "값을 제시할 수 없습니다")
+        detail = f" ({fact.reason})" if fact.reason else ""
+        return f"{label} {fact.quantity}: {why}{detail}."
+
+    magnitude = _format_value(fact.value, fact.unit)
+    per = f"/{fact.perturbation:g}단위" if fact.perturbation else ""
+    return (
+        f"{label} {fact.quantity}: {magnitude}{per}"
+        f"{_validity_phrase(fact)}{_provenance_phrase(fact)}."
+    )
+
+
+def compose_answer_facts_block(facts: Iterable[AnswerFact]) -> dict:
+    """A structured block of composed facts for the LLM to narrate.
+
+    The block separates admitted facts (which carry rendered sentences and their
+    numbers) from refusals (which carry no number at all), and states the hard rule
+    the narrator must obey.
+    """
+    admitted: list[dict] = []
+    refused: list[dict] = []
+    for fact in facts:
+        sentence = compose_fact_sentence(fact)
+        entry = {**fact.to_dict(), "sentence": sentence}
+        (admitted if fact.admissible else refused).append(entry)
+
+    return {
+        "admitted_facts": admitted,
+        "refused_facts": refused,
+        "narration_rule": (
+            "각 사실의 sentence를 그대로 근거로 삼아 자연스럽게 풀어 쓰세요. 숫자·단위·"
+            "유효 범위는 절대 바꾸지 말고, refused_facts의 항목은 숫자를 지어내지 말고 "
+            "제시된 이유대로 '지금은 답할 수 없다'고 말하세요."
+        ),
+    }

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/corpus_quarantine.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/corpus_quarantine.py
@@ -1,0 +1,122 @@
+"""Corpus quarantine: documents that must never reach a grower-facing answer.
+
+Quarantine is enforced at the SQL layer inside :mod:`knowledge_database`, on the
+shared document-filter clause that every retrieval path (FTS, entity, lexical)
+goes through. It is therefore *structurally* impossible for a caller to opt out
+by passing different filters — which is the point. A deny-list that depends on
+callers remembering to apply it is not a deny-list.
+
+Each entry below records **why** the document is quarantined and **what would
+lift it**, because a quarantine with no exit condition is just silent data loss.
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+#: Asset families that are quarantined wholesale.
+#:
+#: ``wiki_page`` / ``wiki_case`` — the LLM Wiki feature was removed from ``main``
+#: on 2026-07-05 (commit ``f01a242``) because it exposed PII and raw source
+#: provenance. The removal deleted the ingest code and ``data/knowledge_wiki/``
+#: but **not** the rows already built into ``artifacts/knowledge/*.sqlite3``, so
+#: 50 documents / 202 chunks outlived both their code and their governance. They
+#: are unreviewable (no source, no ingest, no regeneration path on ``main``), so
+#: they must not be retrievable.
+#:
+#: Exit condition: restore ``data/knowledge_wiki/`` as a PII-scanned,
+#: version-controlled source with a regeneration script and an explicit exposure
+#: boundary, then remove this entry. Re-enabling retrieval without that
+#: governance would re-create the exact failure the 07-05 removal fixed.
+QUARANTINED_ASSET_FAMILIES: frozenset[str] = frozenset({"wiki_page", "wiki_case"})
+
+#: Individual source documents that are quarantined, keyed by lowercase filename.
+#:
+#: The two 農業技術大系 volumes are **Japanese-language books**, not corrupt Korean
+#: ones: their fonts declare ``CIDSystemInfo Registry=Adobe / Ordering=Japan1``
+#: (a CID collection that contains no Hangul glyphs at all) and the text extracts
+#: as ~65% Japanese script with zero Hangul. They are quarantined for two
+#: independent reasons, either of which is sufficient:
+#:
+#: 1. **Agronomic transfer is unverified.** Retrieval judges "relevant to the
+#:    question", never "applicable in a 2026 Korean greenhouse". These are books
+#:    about Japanese cultivars, Japanese climate, Japanese cropping calendars and
+#:    period-specific facilities/materials. In an advisory system the cost of a
+#:    confident wrong prescription exceeds the cost of a miss.
+#: 2. **Licensing is unresolved.** 農文協 sells 大系 commercially as an
+#:    annually-supplemented loose-leaf (加除式) encyclopedia. Berne makes
+#:    reproduction *and translation* exclusive rights; Japan's Copyright Act
+#:    Art. 30-4 (non-enjoyment data analysis) and Art. 47-5 (book-search
+#:    snippets) do not plainly reach advisory RAG that serves the work's content
+#:    to users as translated advice.
+#:
+#: Exit condition: (a) confirm with the publisher/licence that full-text local
+#: indexing and serving answers to users are permitted, and (b) have a Korean
+#: protected-horticulture consultant whitelist specific passages with Korean
+#: annotations. Only then remove entries here — and even then, prefer
+#: passage-level whitelisting over lifting the whole document.
+QUARANTINED_FILENAMES: frozenset[str] = frozenset(
+    {
+        "농업기술대계_토마토편.pdf",
+        "오이_농업기술대계.pdf",
+    }
+)
+
+
+def quarantine_reasons() -> dict[str, str]:
+    """Human-readable reasons, for diagnostics and the catalog surface."""
+    reasons = {
+        family: "ungoverned-orphan: source and ingest removed 2026-07-05 (PII/source exposure)"
+        for family in sorted(QUARANTINED_ASSET_FAMILIES)
+    }
+    reasons.update(
+        {
+            filename: "japanese-source: agronomic transfer unverified and licence unresolved"
+            for filename in sorted(QUARANTINED_FILENAMES)
+        }
+    )
+    return reasons
+
+
+def quarantine_filter_sql(*, document_alias: str = "kd") -> tuple[str, list[Any]]:
+    """Return an AND-able SQL clause excluding every quarantined document.
+
+    The clause is always non-empty so callers cannot accidentally skip it by
+    treating an empty string as "nothing to do".
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if QUARANTINED_ASSET_FAMILIES:
+        families = sorted(QUARANTINED_ASSET_FAMILIES)
+        placeholders = ", ".join("?" for _ in families)
+        clauses.append(
+            f"LOWER(COALESCE({document_alias}.asset_family, '')) NOT IN ({placeholders})"
+        )
+        params.extend(families)
+
+    if QUARANTINED_FILENAMES:
+        filenames = sorted(name.lower() for name in QUARANTINED_FILENAMES)
+        placeholders = ", ".join("?" for _ in filenames)
+        clauses.append(
+            f"LOWER(COALESCE({document_alias}.filename, '')) NOT IN ({placeholders})"
+        )
+        params.extend(filenames)
+
+    if not clauses:
+        return ("1=1", [])
+    return (" AND ".join(clauses), params)
+
+
+def is_quarantined(*, filename: str | None = None, asset_family: str | None = None) -> bool:
+    """Whether a document would be excluded from retrieval."""
+    if asset_family and asset_family.strip().lower() in QUARANTINED_ASSET_FAMILIES:
+        return True
+    if filename and filename.strip().lower() in {
+        name.lower() for name in QUARANTINED_FILENAMES
+    }:
+        return True
+    return False

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_catalog.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_catalog.py
@@ -370,6 +370,8 @@ def _build_asset_entry(spec: dict[str, Any]) -> dict[str, Any]:
         "stage_hints": spec.get("stage_hints", []),
         "normalization_targets": spec.get("normalization_targets", []),
         "sheet_hints": spec.get("sheet_hints", []),
+        # Language the extraction quality gate should hold this document to.
+        "expected_language": spec.get("expected_language", "ko"),
         "exists": exists,
         "readiness": readiness,
         "limitations": limitations,

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
@@ -853,7 +853,16 @@ def _result_score(
     )
 
 
-def _trim_chunk_text(text: str, max_chars: int = 360) -> str:
+#: Result-text budget per retrieved chunk.
+#:
+#: Chunks are stored at `_PDF_CHUNK_CHARS` (1,200) on paragraph/sentence boundaries.
+#: Trimming results to 360 chars discarded ~70% of every chunk the ranker had just
+#: worked to select, and cut the survivor mid-sentence. Returning the whole chunk
+#: keeps retrieval and delivery consistent: what ranked is what the caller gets.
+_MAX_RESULT_TEXT_CHARS = _PDF_CHUNK_CHARS
+
+
+def _trim_chunk_text(text: str, max_chars: int = _MAX_RESULT_TEXT_CHARS) -> str:
     normalized = _normalize_text(text)
     if len(normalized) <= max_chars:
         return normalized

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
@@ -16,6 +16,8 @@ from typing import Any, Iterable, Mapping
 
 from pypdf import PdfReader
 
+from .corpus_quarantine import quarantine_filter_sql
+
 from ..config import settings
 from .knowledge_query_router import route_knowledge_query, routed_relevance_bonus
 from .workbook_normalization import (
@@ -587,6 +589,12 @@ def _document_filter_sql(
     clauses: list[str] = []
     params: list[Any] = []
     filter_payload = filters or {}
+
+    # Quarantine is unconditional: it is applied here, on the clause every
+    # retrieval path shares, so no caller-supplied filter can opt out of it.
+    quarantine_sql, quarantine_params = quarantine_filter_sql(document_alias="kd")
+    clauses.append(quarantine_sql)
+    params.extend(quarantine_params)
 
     if crop:
         clauses.append("kd.crop_scopes_json LIKE ?")

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_database.py
@@ -16,7 +16,8 @@ from typing import Any, Iterable, Mapping
 
 from pypdf import PdfReader
 
-from .corpus_quarantine import quarantine_filter_sql
+from .corpus_quarantine import is_quarantined, quarantine_filter_sql
+from .pdf_quality import assess_document, extract_pdf_pages
 
 from ..config import settings
 from .knowledge_query_router import route_knowledge_query, routed_relevance_bonus
@@ -1193,6 +1194,23 @@ def _extract_pdf_text(page: Any) -> str:
         return page.extract_text() or ""
 
 
+def _extract_pdf_pages_with_quality(
+    path: Path,
+    *,
+    expected_language: str = "ko",
+) -> tuple[list[str], dict[str, Any]]:
+    """Extract per-page text via pdfminer.six and assess it.
+
+    pdfminer resolves CID->Unicode where pypdf cannot, so it recovers more Korean
+    from the guides and readable Japanese from the compendia. The assessment makes a
+    garbage extraction measurable instead of silent; the caller decides what to do
+    with a document that fails.
+    """
+    pages = extract_pdf_pages(path)
+    assessment = assess_document(pages, expected_language=expected_language)
+    return pages, assessment.to_dict()
+
+
 def _ingest_telemetry_asset(
     connection: sqlite3.Connection,
     *,
@@ -1318,13 +1336,27 @@ def _ingest_pdf_asset(
     crop_scope: str,
     document_id: int,
     asset: dict[str, Any],
-) -> None:
+) -> dict[str, Any]:
+    """Ingest a PDF's chunks and return its extraction-quality assessment.
+
+    Quarantined documents (Japanese compendia) are still assessed so their quality is
+    on record, but their chunks are not indexed — no point storing text that retrieval
+    can never return. The assessment is returned so the catalog build can fail on a
+    Korean-expected document that extracts as garbage.
+    """
     path = REPO_ROOT / asset["relative_path"]
-    reader = _open_pdf_reader(path)
+    expected_language = str(asset.get("expected_language", "ko"))
+    pages, quality = _extract_pdf_pages_with_quality(
+        path, expected_language=expected_language
+    )
+    if is_quarantined(filename=asset.get("filename"), asset_family=asset.get("asset_family")):
+        quality["ingested"] = False
+        quality["skip_reason"] = "quarantined"
+        return quality
+
     topic_major = asset.get("topic_hints", [asset["asset_family"]])[0]
     ordinal = 1
-    for page_index, page in enumerate(reader.pages, start=1):
-        text = _extract_pdf_text(page)
+    for page_index, text in enumerate(pages, start=1):
         for chunk in _build_text_chunks(text):
             chunk_id = _insert_chunk(
                 connection,
@@ -1350,6 +1382,10 @@ def _ingest_pdf_asset(
                 ),
             )
             ordinal += 1
+
+    quality["ingested"] = True
+    quality["chunks"] = ordinal - 1
+    return quality
 
 
 def _ingest_workbook_previews(
@@ -1919,6 +1955,14 @@ def _insert_crop_profile(connection: sqlite3.Connection, payload: dict[str, Any]
     )
 
 
+class CorpusQualityError(RuntimeError):
+    """A build was blocked because a required document failed the quality gate.
+
+    Raised before the temp->final promotion, so the existing (last-known-good) index
+    is left untouched rather than replaced with a corrupt one.
+    """
+
+
 def rebuild_knowledge_database(payload: dict[str, Any]) -> dict[str, Any]:
     crop_scope = _scope_slug(payload.get("crop_scope"))
     db_path = knowledge_db_path(crop_scope)
@@ -1978,6 +2022,7 @@ def rebuild_knowledge_database(payload: dict[str, Any]) -> dict[str, Any]:
         )
         _insert_crop_profile(connection, payload)
 
+        pdf_quality: dict[str, dict[str, Any]] = {}
         for asset in payload.get("assets", []):
             document_id = document_ids[asset["filename"]]
             if asset.get("readiness") != "ready":
@@ -1990,12 +2035,32 @@ def rebuild_knowledge_database(payload: dict[str, Any]) -> dict[str, Any]:
                     asset=asset,
                 )
             elif asset["source_type"] == "pdf":
-                _ingest_pdf_asset(
+                pdf_quality[asset["filename"]] = _ingest_pdf_asset(
                     connection,
                     crop_scope=crop_scope,
                     document_id=document_id,
                     asset=asset,
                 )
+
+        # Promotion gate: a Korean-expected PDF that extracted real text which is the
+        # wrong language (or junk) must not be atomically promoted. Before 2026-07-17
+        # the catalog marked documents ready by page count alone and the temp->final
+        # swap had no quality check, so a fully-built garbage index shipped silently.
+        #
+        # A document that extracted *no* letters (empty or image-only) is recorded as
+        # needing OCR but does not block the build — it contributes no chunks, so it
+        # cannot poison retrieval, unlike garbage text that produces garbage chunks.
+        gate_failures = [
+            f"{filename}: {quality.get('reason')}"
+            for filename, quality in pdf_quality.items()
+            if quality.get("ingested")
+            and not quality.get("passes")
+            and int(quality.get("letters", 0)) > 0
+        ]
+        if gate_failures:
+            raise CorpusQualityError(
+                "PDF extraction quality gate failed for: " + "; ".join(gate_failures)
+            )
 
         pesticide_document_id = document_ids.get("농약 솔루션_260326_v1.xlsx")
         pesticide_asset = next(
@@ -2022,7 +2087,14 @@ def rebuild_knowledge_database(payload: dict[str, Any]) -> dict[str, Any]:
             )
 
         connection.commit()
-    finally:
+    except BaseException:
+        connection.close()
+        # Do not promote a temp build that failed the gate or errored midway; leave
+        # the last-known-good index in place.
+        if temp_path.exists():
+            temp_path.unlink()
+        raise
+    else:
         connection.close()
 
     temp_path.replace(db_path)

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_query_router.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/knowledge_query_router.py
@@ -42,7 +42,7 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "결로",
             "이산화탄소",
         },
-        "search_filters": {"source_types": ["pdf", "csv"], "topic_major": "environment"},
+        "search_filters": {"source_types": ["pdf", "csv", "markdown"], "topic_major": "environment"},
         "boosts": {
             "source_types": ["pdf", "csv"],
             "topic_majors": ["environment"],
@@ -65,6 +65,7 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "growth",
             "balance",
             "생리",
+            "생리장해",
             "광합성",
             "증산",
             "기공",
@@ -73,8 +74,13 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "개화",
             "생육",
             "초세",
+            "마디",
+            "절간",
+            "화방",
+            "엽면적",
+            "장해",
         },
-        "search_filters": {"source_types": ["pdf"], "topic_major": "physiology"},
+        "search_filters": {"source_types": ["pdf", "markdown"], "topic_major": "physiology"},
         "boosts": {
             "source_types": ["pdf"],
             "topic_majors": ["physiology", "growth"],
@@ -112,7 +118,7 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "증상",
             "진단",
         },
-        "search_filters": {"source_types": ["pdf", "xlsx"]},
+        "search_filters": {"source_types": ["pdf", "xlsx", "markdown"]},
         "boosts": {
             "asset_families": ["pesticide_workbook"],
             "source_types": ["xlsx"],
@@ -189,7 +195,7 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "체크리스트",
             "수확작업",
         },
-        "search_filters": {"source_types": ["pdf"]},
+        "search_filters": {"source_types": ["pdf", "markdown"]},
         "boosts": {
             "source_types": ["pdf"],
             "topic_majors": ["management", "growth"],
@@ -217,7 +223,7 @@ _PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "도매",
             "소매",
         },
-        "search_filters": {"source_types": ["pdf", "csv"]},
+        "search_filters": {"source_types": ["pdf", "csv", "markdown"]},
         "boosts": {
             "source_types": ["pdf", "csv"],
             "topic_majors": ["management", "growth"],
@@ -271,6 +277,19 @@ _ANALYTE_EXPANSIONS = {
     "nh4": "ammonium",
 }
 
+#: Substrings that are re-emitted as standalone tokens when they appear inside a
+#: longer word.
+#:
+#: Korean is agglutinative, so a naturally phrased question never yields the bare
+#: keyword: a grower writes "생리장해", "광합성이", "착과율이", not "생리 광합성 착과".
+#: ``_detect_intent`` scores by exact set intersection, so without an entry here a
+#: profile keyword is unreachable for real questions. Before 2026-07-17 this tuple
+#: held 23 terms covering cultivation and pest vocabulary but **none** of the
+#: physiology vocabulary, which left ``crop_physiology`` effectively dead: all four
+#: of the maintainer's real physiology questions fell through to ``general_chat``.
+#:
+#: Keep this list ordered coarse-to-fine within a family so that both the compound
+#: and its head are emitted (e.g. "생리장해" yields both "생리" and "장해").
 _KOREAN_COMPOUND_TERMS = (
     "오이",
     "토마토",
@@ -294,6 +313,22 @@ _KOREAN_COMPOUND_TERMS = (
     "노균",
     "나방류",
     "약제",
+    # Physiology vocabulary. Without these, `crop_physiology` never fires for a
+    # naturally phrased Korean question.
+    "생리장해",
+    "생리",
+    "광합성",
+    "증산",
+    "기공",
+    "착과",
+    "개화",
+    "초세",
+    "마디",
+    "절간",
+    "화방",
+    "엽면적",
+    "수관",
+    "장해",
 )
 
 
@@ -457,6 +492,9 @@ def _apply_sub_intent_profile(
     boosts = adjusted.setdefault("boosts", {})
 
     if intent == "disease_pest":
+        # `cycle_recommendation` and `product_recommendation` are structured
+        # lookups against the pesticide workbook, so they stay deliberately narrow
+        # — prose sources (pdf/markdown) must not dilute a registration answer.
         if sub_intent == "cycle_recommendation":
             adjusted["search_filters"] = {
                 "asset_families": ["pesticide_workbook"],
@@ -470,7 +508,8 @@ def _apply_sub_intent_profile(
             }
             boosts["topic_minors"] = ["pesticide_product"]
         else:
-            adjusted["search_filters"] = {"source_types": ["pdf", "xlsx"]}
+            # Symptom/diagnosis questions are prose questions; keep them broad.
+            adjusted["search_filters"] = {"source_types": ["pdf", "xlsx", "markdown"]}
         return adjusted
 
     if intent == "nutrient_recipe":

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/model_runtime/sensitivity_engine.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/model_runtime/sensitivity_engine.py
@@ -16,15 +16,43 @@ SUPPORTED_DERIVATIVE_TARGETS = {
     "canopy_A_24h": ("canopy_A_pred", 24),
     "canopy_A_72h": ("canopy_A_pred", 72),
     "transpiration_72h": ("transpiration_pred", 72),
-    "energy_cost_72h": ("energy_cost_pred", 72),
+    # NOT money. Despite the `energy_cost_pred` field name, this resolves to
+    # `scenario_runner._project_output_row`'s
+    #     energy_cost_pred = horizon_days * (0.75 + energy_rate_delta)
+    # where `energy_rate_delta` is a unitless composite of normalized deviations
+    # and 0.75 is an undocumented constant. It is never multiplied by kWh or by
+    # `cost_per_kwh`, so its derivative is an index gradient, not ₩/℃.
+    #
+    # Renamed from `energy_cost_72h` on 2026-07-17: a target named "cost" that
+    # holds a dimensionless index is a trap for every later reader, human or model.
+    # The real currency derivative lives in the RTR subsystem
+    # (`rtr/objective_terms.py` -> `heating_energy_cost_krw`, `cost_per_kwh`).
+    "energy_load_index_72h": ("energy_cost_pred", 72),
     "source_sink_balance_72h": ("source_sink_balance_score", 72),
 }
+
+#: Retired target names kept resolvable so stored/scripted callers do not break.
+#: Not advertised: `SUPPORTED_DERIVATIVE_TARGETS` is what callers should discover.
+DEPRECATED_DERIVATIVE_TARGET_ALIASES = {
+    "energy_cost_72h": "energy_load_index_72h",
+}
+
+#: Targets that must never be rendered as a monetary amount, because they are not
+#: denominated in currency. `answer_composer` enforces this; the constant lives here
+#: so the ban travels with the definition rather than with a call site.
+NON_MONETARY_TARGETS = frozenset({"energy_load_index_72h"})
+
+
+def resolve_derivative_target(derivative_target: str) -> str:
+    """Canonical target name, following deprecated aliases."""
+    return DEPRECATED_DERIVATIVE_TARGET_ALIASES.get(derivative_target, derivative_target)
 
 
 def _resolve_target_value(
     scenario_payload: Mapping[str, Any],
     derivative_target: str,
 ) -> float:
+    derivative_target = resolve_derivative_target(derivative_target)
     if derivative_target not in SUPPORTED_DERIVATIVE_TARGETS:
         raise ValueError(f"Unsupported derivative target: {derivative_target}")
 
@@ -85,6 +113,10 @@ def compute_local_sensitivities(
 ) -> dict[str, Any]:
     """Compute bounded finite-difference sensitivities around the current snapshot."""
     del horizon_hours  # The derivative target controls which horizon is consumed today.
+
+    derivative_target = resolve_derivative_target(derivative_target)
+    if derivative_target not in SUPPORTED_DERIVATIVE_TARGETS:
+        raise ValueError(f"Unsupported derivative target: {derivative_target}")
 
     selected_controls = controls or list(CONTROL_SPECS)
     unknown_controls = sorted(control for control in selected_controls if control not in CONTROL_SPECS)

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/openai_service.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/openai_service.py
@@ -296,6 +296,26 @@ def _chat_grounding_block(dashboard: Dict[str, Any], language: str) -> str:
     """
     cards = _evidence_cards(dashboard)
     if not cards:
+        # No evidence must be visible as no evidence, not silently identical to a
+        # grounded answer. Surface the grounding decision so the reply can say it
+        # is speaking from general knowledge rather than the local references.
+        knowledge = dashboard.get("knowledge") if isinstance(dashboard, dict) else None
+        decision = (
+            str(knowledge.get("grounding_decision") or "")
+            if isinstance(knowledge, dict)
+            else ""
+        )
+        if decision and decision != "GROUNDED":
+            if language.lower().startswith("en"):
+                return (
+                    f"Retrieval status: {decision}. No local reference supports this "
+                    "question. Answer from general knowledge and say so plainly; do not "
+                    "imply you consulted the references.\n\n"
+                )
+            return (
+                f"검색 상태: {decision}. 이 질문을 뒷받침하는 로컬 문헌이 없습니다. "
+                "일반 지식으로 답하되 그렇다고 밝히고, 문헌을 참고한 것처럼 말하지 마세요.\n\n"
+            )
         return ""
 
     excerpts = []

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/openai_service.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/openai_service.py
@@ -173,8 +173,23 @@ def _system_prompt(crop: str, language: str = "ko") -> str:
 
 
 def _chat_system_prompt(crop: str, language: str = "ko") -> str:
-    """Conversational system prompt for chat: natural dialogue, no report
-    scaffolding, and never cite sources."""
+    """Conversational system prompt for chat.
+
+    The register stays conversational — no report cards, no fixed sections — which
+    is the point of the natural-conversation chat. What changed on 2026-07-17 is
+    that the prompt no longer forbids the *substance* along with the scaffolding.
+
+    The previous version told the model "리포트 구조 쓰지 마세요" and "출처·자료명을
+    절대 언급하지 마세요 — 그냥 원래 아는 것처럼 자연스럽게 말하세요", then handed it
+    retrieved literature under a header saying never to quote it. Read as a spec,
+    that says: do not structure, do not attribute, do not show your work. Weak,
+    unquantified answers were the prompt being obeyed.
+
+    Natural and quantitative are not opposites: a real consultant says "1도 올리면
+    난방비가 하루 4만원쯤 더 나오고, 마디는 주당 0.07마디쯤 빨라집니다. 다만 이건
+    ±1.5도 범위에서만 맞는 계산이에요" — conversationally, with numbers, with a
+    validity range, without a report card.
+    """
     crop_norm = (crop or "").strip().lower()
     if crop_norm == "tomato":
         focus_ko = "토마토는 착과·비대, VPD·증산, 광합성·기공, 생식/영양 균형, 수확 전망, CO2·광, 에너지를 함께 봅니다."
@@ -188,53 +203,126 @@ def _chat_system_prompt(crop: str, language: str = "ko") -> str:
 
     if language.lower().startswith("en"):
         return (
-            "You are an experienced greenhouse grower talking with a farmer. "
-            "Answer the question directly and conversationally, like a real chat — "
-            "no report structure, no headings, no fixed sections. Write in short, natural "
-            "paragraphs; use a brief list only when it genuinely helps. "
-            "Draw on the background knowledge and model calculations you are given, but "
-            "NEVER mention sources, references, documents, data numbers, or that you consulted "
-            "anything — just speak as someone who knows. Do not fabricate missing measurements; "
-            "if something is unknown, say so plainly. "
+            "You are a senior protected-horticulture consultant talking with a grower. "
+            "Answer directly and conversationally, like a real chat — no report structure, "
+            "no headings, no fixed sections. Write in short, natural paragraphs; use a brief "
+            "list only when it genuinely helps.\n\n"
+            "Be a specialist, not a reassurer:\n"
+            "- When you give a number, give its unit and the range it is valid over. "
+            "\"Cost will rise somewhat\" is a failure; \"about ₩40,000/day more, and that "
+            "figure only holds within ±1.5°C of where you are now\" is the job.\n"
+            "- Use the model calculations you are given as the source of any number. Never "
+            "compute, adjust, rescale, or round a number into a different one, and never "
+            "supply a number that was not given to you.\n"
+            "- If a calculation is flagged as unreliable or out of range, say so plainly and "
+            "do not give the number anyway.\n"
+            "- You may refer to the background knowledge naturally, the way a consultant "
+            "cites what they read (\"the RDA guide puts it around ...\"). Do not invent a "
+            "source, and do not attach reference numbers or a citation list.\n"
+            "- If you do not know, or nothing in the context supports an answer, say so. An "
+            "honest \"I'd need to measure X first\" beats a fluent guess.\n"
             f"{focus_en}"
         )
 
     return (
-        "당신은 농가와 편하게 대화하는 노련한 온실 재배 전문가입니다. "
+        "당신은 농가와 대화하는 시니어 시설원예 컨설턴트입니다. "
         "질문에 곧바로, 대화하듯 자연스럽게 답하세요 — 리포트 구조나 제목·소제목·고정된 항목 나열은 쓰지 마세요. "
-        "짧고 자연스러운 문단으로 말하고, 목록은 정말 도움이 될 때만 간단히 쓰세요. "
-        "제공된 배경 지식과 모델 계산을 활용하되, '참고 자료', '출처', 문서·자료 이름, 자료 번호, 근거를 찾아봤다는 표현을 "
-        "답변에 절대 언급하지 마세요 — 그냥 원래 아는 것처럼 자연스럽게 말하세요. "
-        "없는 값을 지어내지 말고, 모르는 것은 솔직히 모른다고 하세요. "
+        "짧고 자연스러운 문단으로 말하고, 목록은 정말 도움이 될 때만 간단히 쓰세요.\n\n"
+        "안심시키는 사람이 아니라 전문가로 답하세요:\n"
+        "- 숫자를 말할 때는 반드시 단위와 그 숫자가 유효한 범위를 함께 말하세요. "
+        "'비용이 다소 증가합니다'는 실패한 답변이고, '하루 4만원쯤 더 나오는데 이건 지금 온도에서 ±1.5도 안에서만 "
+        "맞는 계산이에요'가 제대로 된 답변입니다.\n"
+        "- 모든 숫자는 제공된 모델 계산에서만 가져오세요. 직접 계산하거나 환산·반올림해서 다른 숫자로 바꾸지 말고, "
+        "주어지지 않은 숫자는 절대 만들어내지 마세요.\n"
+        "- 계산이 '신뢰할 수 없음' 또는 '범위 밖'으로 표시돼 있으면 그 사실을 그대로 말하고, 숫자는 말하지 마세요.\n"
+        "- 배경 지식은 컨설턴트가 읽은 것을 인용하듯 자연스럽게 언급해도 됩니다('농업기술길잡이 기준으로는 대략 ...'). "
+        "다만 없는 출처를 지어내지 말고, 자료 번호나 참고문헌 목록은 붙이지 마세요.\n"
+        "- 모르면 모른다고 하세요. 맥락에 근거가 없으면 '먼저 ○○를 재봐야 알겠다'가 유창한 추측보다 낫습니다.\n"
         f"{focus_ko}"
     )
 
 
-def _chat_grounding_block(dashboard: Dict[str, Any], language: str) -> str:
-    """Inline the retrieved manual/compendium excerpts as background knowledge,
-    with a hard rule never to surface them as citations."""
+#: How many retrieved excerpts reach the model. The retrieval layer caps the count
+#: (`advisor_context_builder._MAX_CHAT_RESULTS`); this is the belt-and-braces bound
+#: for callers that assemble a dashboard by hand.
+_MAX_GROUNDING_CARDS = 6
+
+
+def _evidence_cards(dashboard: Any) -> list[Any]:
+    """Retrieved evidence cards, or an empty list when retrieval produced none."""
     knowledge = dashboard.get("knowledge") if isinstance(dashboard, dict) else None
-    retrieval = (knowledge or {}).get("advisor_retrieval_context") if isinstance(knowledge, dict) else None
-    cards = (retrieval or {}).get("evidence_cards") if isinstance(retrieval, dict) else None
+    retrieval = (
+        knowledge.get("advisor_retrieval_context") if isinstance(knowledge, dict) else None
+    )
+    cards = retrieval.get("evidence_cards") if isinstance(retrieval, dict) else None
+    return list(cards) if isinstance(cards, list) else []
+
+
+def _dashboard_without_evidence_cards(dashboard: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy of the dashboard with the retrieved excerpts removed.
+
+    The excerpts are carried by `_chat_grounding_block`. Leaving them in the JSON
+    dump as well sent every excerpt to the model twice — pure token cost with no
+    added grounding. The retrieval *status* is kept so the model can still tell a
+    grounded answer from an ungrounded one.
+    """
+    if not isinstance(dashboard, dict):
+        return {}
+    knowledge = dashboard.get("knowledge")
+    if not isinstance(knowledge, dict):
+        return dict(dashboard)
+    retrieval = knowledge.get("advisor_retrieval_context")
+    if not isinstance(retrieval, dict):
+        return dict(dashboard)
+
+    trimmed_retrieval = {
+        key: value for key, value in retrieval.items() if key != "evidence_cards"
+    }
+    trimmed_retrieval["evidence_cards_omitted"] = (
+        "inlined above as the evidence block; omitted here to avoid duplicate transmission"
+    )
+    trimmed_knowledge = dict(knowledge)
+    trimmed_knowledge["advisor_retrieval_context"] = trimmed_retrieval
+    trimmed = dict(dashboard)
+    trimmed["knowledge"] = trimmed_knowledge
+    return trimmed
+
+
+def _chat_grounding_block(dashboard: Dict[str, Any], language: str) -> str:
+    """Inline the retrieved manual/compendium excerpts as the reply's evidence.
+
+    This block is the *only* place the excerpts are serialized: `generate_chat_reply`
+    strips them out of the dashboard JSON so the same text is not transmitted twice.
+    """
+    cards = _evidence_cards(dashboard)
     if not cards:
         return ""
 
     excerpts = []
-    for card in cards[:5]:
+    for card in cards[:_MAX_GROUNDING_CARDS]:
         excerpt = str((card or {}).get("evidence_excerpt") or "").strip()
-        if excerpt:
-            excerpts.append(f"- {excerpt}")
+        if not excerpt:
+            continue
+        topic = str((card or {}).get("topic_major") or "").strip()
+        excerpts.append(f"- [{topic}] {excerpt}" if topic else f"- {excerpt}")
     if not excerpts:
         return ""
 
     body = "\n".join(excerpts)
     if language.lower().startswith("en"):
         return (
-            "Background knowledge you may draw on (do NOT quote, cite, or name any of it in your reply):\n"
+            "Evidence retrieved from the local agronomy references for this question. "
+            "Ground your answer in it, and refer to it naturally the way a consultant "
+            "cites what they read. Do not invent sources, and do not add reference "
+            "numbers or a citation list. If it does not answer the question, say so "
+            "rather than filling the gap:\n"
             f"{body}\n\n"
         )
     return (
-        "답변에 활용할 배경 지식입니다 (이 내용을 인용하거나 출처·자료명을 답변에 절대 쓰지 마세요):\n"
+        "이 질문에 대해 로컬 농업 문헌에서 검색된 근거입니다. 답변을 여기에 근거해 작성하고, "
+        "컨설턴트가 읽은 것을 인용하듯 자연스럽게 언급하세요. 없는 출처를 지어내지 말고 "
+        "자료 번호나 참고문헌 목록은 붙이지 마세요. 이 근거가 질문에 답하지 못하면 "
+        "빈틈을 메우지 말고 모른다고 하세요:\n"
         f"{body}\n\n"
     )
 
@@ -545,29 +633,35 @@ def generate_chat_reply(
     the reply must read like ordinary conversation and never cite any of it."""
     ctx = dashboard or {}
     grounding_block = _chat_grounding_block(ctx, language)
+    # The excerpts live in `grounding_block`; strip them from the JSON so the same
+    # text is not transmitted twice.
+    ctx_json = _dashboard_without_evidence_cards(ctx)
     if language.lower().startswith("en"):
         context_intro = (
-            "The following is PRIVATE context to help you answer — the current greenhouse "
-            "readings, background knowledge, and model calculations. Use it to inform your "
-            "answer, but never quote it, cite it, name a source, or say you looked anything up.\n\n"
+            "The following is context for your answer — the current greenhouse readings and "
+            "the model's calculations. It is working material, not something to read out: "
+            "do not dump the JSON back at the grower.\n\n"
             "Reading the numbers: currentData holds live readings "
             "(temperature °C, humidity %, co2 ppm, light PAR, vpd kPa, transpiration mm/h, "
             "stomatalConductance mol m⁻² s⁻¹, photosynthesis µmol m⁻² s⁻¹, energyUsage kW); "
             "weather is the live Daegu outlook; rtr is the temperature-strategy state; "
-            "model_runtime holds calculated what-if effects — lean on those effects for "
-            "what-if questions and explain the change in plain language. "
-            "Use only the numbers given; do not invent missing ones.\n\n"
+            "model_runtime holds the calculated what-if effects.\n\n"
+            "Every number in your reply must come from here verbatim. Do not recompute, "
+            "rescale, or interpolate — in particular, never extrapolate a small step to a "
+            "larger one the model was not asked about. If a value is missing or flagged "
+            "unreliable, say so instead of estimating it.\n\n"
         )
     else:
         context_intro = (
-            "아래는 답변을 돕기 위한 비공개 참고 정보입니다 — 현재 온실 계측값, 배경 지식, 모델 계산 결과입니다. "
-            "이 정보를 바탕으로 답하되, 인용하거나 출처·자료명을 말하거나 뭔가 찾아봤다는 티를 내지 마세요.\n\n"
+            "아래는 답변에 쓸 컨텍스트입니다 — 현재 온실 계측값과 모델 계산 결과입니다. "
+            "작업용 자료이지 읽어줄 내용이 아니니, JSON을 그대로 농가에게 늘어놓지 마세요.\n\n"
             "수치 읽는 법: currentData는 실시간 계측값입니다 "
             "(temperature ℃, humidity %, co2 ppm, light 광량, vpd kPa, transpiration mm/h, "
             "stomatalConductance mol m⁻² s⁻¹, photosynthesis µmol m⁻² s⁻¹, energyUsage kW). "
-            "weather는 대구 외기, rtr는 온도 전략 상태, model_runtime은 계산된 what-if 효과입니다 — "
-            "'~하면 어떻게 되나' 류 질문은 이 계산 효과를 근거로 쉬운 말로 설명하세요. "
-            "주어진 수치만 쓰고 없는 값은 지어내지 마세요.\n\n"
+            "weather는 대구 외기, rtr는 온도 전략 상태, model_runtime은 계산된 what-if 효과입니다.\n\n"
+            "답변에 등장하는 모든 숫자는 여기에서 그대로 가져와야 합니다. 직접 다시 계산하거나 "
+            "환산·보간하지 마세요 — 특히 작은 변화량의 계산 결과를 모델이 계산하지 않은 큰 변화량으로 "
+            "외삽하지 마세요. 값이 없거나 신뢰할 수 없다고 표시돼 있으면 추정하지 말고 그렇다고 말하세요.\n\n"
         )
 
     input_messages: List[Dict[str, str]] = [
@@ -577,7 +671,7 @@ def generate_chat_reply(
                 f"{context_intro}"
                 f"{grounding_block}"
                 f"작물: {crop}\n"
-                f"참고 정보(JSON):\n{json.dumps(ctx, ensure_ascii=False)}"
+                f"참고 정보(JSON):\n{json.dumps(ctx_json, ensure_ascii=False)}"
             ),
         }
     ]

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/pdf_quality.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/pdf_quality.py
@@ -1,0 +1,152 @@
+"""PDF text extraction with an expected-language quality gate.
+
+Two failures the council found here:
+
+1. The two 農業技術大系 volumes (2,353 pages) ingested as 0.0%-Hangul glyph soup because
+   pypdf could not resolve their Adobe-Japan1 CID fonts, which have no ToUnicode CMap.
+2. The ingest suppressed the very pypdf "Advanced encoding … not implemented yet" warning
+   and the `pypdf._cmap` logger — the one diagnostic that would have revealed it — and the
+   catalog marked documents ready by page count alone, so a fully-built garbage index got
+   atomically promoted with nothing to stop it.
+
+This module fixes both. `pdfminer.six` (MIT) resolves the CID mapping from an external
+table where pypdf cannot, so it extracts more Korean from the Korean guides and recovers
+readable Japanese from the compendia. And `assess_extraction` measures the expected-language
+character share so a document that extracts as garbage fails the gate instead of shipping.
+
+The gate does not by itself decide what happens to a failing document — the caller does
+(quarantine, OCR fallback, or block the build). It just makes the corruption *visible and
+measurable* rather than silent.
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+#: Below this Hangul share (of letters) a Korean-expected document is treated as
+#: unreadable. The healthy Korean guides sit at 60-84%; the CID-soup compendia at 0%.
+_MIN_HANGUL_SHARE_KO = 0.20
+
+#: Replacement / private-use / control characters above this share signal a decode
+#: failure regardless of language.
+_MAX_JUNK_SHARE = 0.02
+
+_HANGUL = re.compile(r"[가-힣]")
+_LETTER = re.compile(r"[^\W\d_]", re.UNICODE)
+_JUNK = re.compile(r"[�-\x00-\x08\x0e-\x1f]")
+
+
+@dataclass(frozen=True)
+class ExtractionAssessment:
+    """The measured quality of an extracted document."""
+
+    chars: int
+    letters: int
+    hangul_share: float
+    junk_share: float
+    expected_language: str
+    passes: bool
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "chars": self.chars,
+            "letters": self.letters,
+            "hangul_share": round(self.hangul_share, 4),
+            "junk_share": round(self.junk_share, 4),
+            "expected_language": self.expected_language,
+            "passes": self.passes,
+            "reason": self.reason,
+        }
+
+
+def extract_pdf_pages(path: Path) -> list[str]:
+    """Per-page text via pdfminer.six, resolving CID fonts pypdf cannot.
+
+    Returns one string per page, in order. Extraction warnings are surfaced (not
+    suppressed): a document that warns is a document to look at.
+    """
+    from pdfminer.high_level import extract_pages
+    from pdfminer.layout import LTTextContainer
+    from pdfminer.pdfparser import PDFSyntaxError
+
+    # An empty or malformed file yields no pages rather than raising, so the caller
+    # can distinguish "unreadable" (a quality result) from a hard crash. A real
+    # 0-byte or truncated PDF then simply fails the gate on "no extractable letters".
+    if not path.exists() or path.stat().st_size == 0:
+        return []
+
+    pages: list[str] = []
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("default")
+            for layout in extract_pages(str(path)):
+                parts = [
+                    element.get_text()
+                    for element in layout
+                    if isinstance(element, LTTextContainer)
+                ]
+                pages.append("".join(parts))
+    except (PDFSyntaxError, ValueError) as exc:
+        logger.warning("pdfminer could not parse %s: %s", path.name, exc)
+        return []
+    return pages
+
+
+def assess_extraction(text: str, *, expected_language: str = "ko") -> ExtractionAssessment:
+    """Score extracted text against its expected language.
+
+    `expected_language`:
+      - "ko": Korean prose; requires a minimum Hangul share.
+      - "any"/other: only the junk-character check applies (for structured or
+        legitimately non-Korean documents).
+    """
+    chars = len(text)
+    letters = len(_LETTER.findall(text))
+    hangul = len(_HANGUL.findall(text))
+    junk = len(_JUNK.findall(text))
+    hangul_share = (hangul / letters) if letters else 0.0
+    junk_share = (junk / chars) if chars else 0.0
+
+    if junk_share > _MAX_JUNK_SHARE:
+        return ExtractionAssessment(
+            chars, letters, hangul_share, junk_share, expected_language,
+            passes=False,
+            reason=f"junk-character share {junk_share:.3f} exceeds {_MAX_JUNK_SHARE}",
+        )
+
+    if expected_language == "ko":
+        if letters == 0:
+            return ExtractionAssessment(
+                chars, letters, hangul_share, junk_share, expected_language,
+                passes=False, reason="no extractable letters",
+            )
+        if hangul_share < _MIN_HANGUL_SHARE_KO:
+            return ExtractionAssessment(
+                chars, letters, hangul_share, junk_share, expected_language,
+                passes=False,
+                reason=(
+                    f"Hangul share {hangul_share:.3f} is below {_MIN_HANGUL_SHARE_KO} "
+                    "for a Korean-expected document (likely a CID/encoding failure or a "
+                    "non-Korean source)"
+                ),
+            )
+
+    return ExtractionAssessment(
+        chars, letters, hangul_share, junk_share, expected_language,
+        passes=True, reason="ok",
+    )
+
+
+def assess_document(pages: list[str], *, expected_language: str = "ko") -> ExtractionAssessment:
+    """Assess a whole document from its per-page text."""
+    return assess_extraction("\n".join(pages), expected_language=expected_language)

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/pesticide_safety.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/pesticide_safety.py
@@ -1,0 +1,113 @@
+"""Pesticide safety gate: refuse legally-binding numbers the local data cannot support.
+
+Korean pesticide safe-use standards (안전사용기준: 수확 전 사용일수/PHI, 사용 횟수, 희석배수)
+are legally binding. 농약관리법 제23조 requires growers to follow them and prohibits
+recommending use that deviates from them. So a wrong PHI is not a quality defect, it is a
+legal one.
+
+The local ``pesticide_products`` table has **no PHI column and no application-count column**
+(product_id, crop_scope, category, product_name, active_ingredient, moa_code_group,
+registration_status, dilution, cycle_recommendation, mixing_caution, …). The safe-use
+standard survives only as free text inside ``cycle_recommendation``, and even there it
+defers ("제형에 따라 수확전일수·횟수 …"). The system therefore **cannot** return a correct PHI,
+and an LLM parsing it out of prose — or inventing it from memory — is exactly the failure to
+prevent.
+
+This module decides when a pesticide question is asking for a legally-consequential number
+the data cannot supply, and provides the refusal + authoritative pointer. What the schema
+*does* support (MoA/resistance-group rotation, tank-mix cautions, registration status) stays
+answerable.
+
+Authoritative source: RDA 농약안전정보시스템 (PSIS), which publishes 안전사용기준 via public
+OpenAPI on data.go.kr. A live gateway is a separate, credentialed integration; until it
+exists the safe behaviour is to refuse the number and point there.
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/improvement_spec.md
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+#: The authoritative Korean registry for safe-use standards.
+PSIS_URL = "https://psis.rda.go.kr/"
+PSIS_OPENAPI_REGISTRATION = "https://www.data.go.kr/data/15057994/openapi.do"
+PSIS_OPENAPI_SAFE_USE = "https://www.data.go.kr/data/15059306/openapi.do"
+
+#: Question patterns that ask for a legally-binding number the schema cannot supply.
+#: Korean + a little English; matched case-insensitively against the raw question.
+_PHI_QUESTION_PATTERNS = (
+    r"수확\s*전\s*(?:며칠|사용\s*일수|일수)",
+    r"수확\s*(?:몇\s*일\s*전|얼마\s*전)",
+    r"안전\s*사용\s*기준",
+    r"사용\s*횟수",
+    r"몇\s*번\s*(?:까지)?\s*(?:칠|뿌|살포|사용)",
+    r"희석\s*(?:배수|비율|농도)",
+    r"\bphi\b",
+    r"pre[-\s]?harvest",
+)
+
+#: Sub-topics the local schema genuinely supports.
+_SUPPORTED_TOPICS = {
+    "rotation": ("moa_code_group",),
+    "mixing": ("mixing_caution",),
+    "registration": ("registration_status",),
+}
+
+
+def asks_for_safe_use_number(question: str) -> bool:
+    """Whether the question asks for a PHI / application-count / dilution figure."""
+    text = (question or "").lower()
+    return any(re.search(pattern, text) for pattern in _PHI_QUESTION_PATTERNS)
+
+
+def safe_use_refusal(*, language: str = "ko") -> dict[str, Any]:
+    """The refusal payload for a safe-use-number question.
+
+    An advisory system owes the grower the authoritative source when its own data
+    cannot answer, not a best-effort guess.
+    """
+    if language.lower().startswith("en"):
+        message = (
+            "I can't give a safe-use figure (pre-harvest interval, application count, or "
+            "dilution) from the local data — it does not carry those fields, and they are "
+            "legally binding, so a guess is not acceptable. Check the exact product label "
+            "and the RDA pesticide safe-use registry (PSIS) at "
+            f"{PSIS_URL}. I can still help with resistance-group rotation, tank-mix "
+            "cautions, and registration status."
+        )
+    else:
+        message = (
+            "안전사용기준(수확 전 사용일수·사용 횟수·희석배수)은 로컬 데이터에 해당 항목이 없어 "
+            "정확히 알려드릴 수 없습니다. 이 값들은 법적 기준이라 추측으로 답하면 안 됩니다. "
+            f"제품 라벨과 농촌진흥청 농약안전정보시스템(PSIS, {PSIS_URL})에서 정확한 값을 확인하세요. "
+            "대신 교호방제(계통 로테이션), 혼용 주의, 등록 상태는 도와드릴 수 있습니다."
+        )
+    return {
+        "status": "refused_safe_use_standard",
+        "reason": "local schema has no PHI/application-count/dilution field; the figure is "
+        "legally binding and must come from the authoritative registry",
+        "authoritative_sources": {
+            "registry": PSIS_URL,
+            "openapi_registration": PSIS_OPENAPI_REGISTRATION,
+            "openapi_safe_use": PSIS_OPENAPI_SAFE_USE,
+        },
+        "supported_topics": sorted(_SUPPORTED_TOPICS),
+        "message": message,
+    }
+
+
+def schema_supports(topic: str, columns: Mapping[str, Any] | None = None) -> bool:
+    """Whether the pesticide schema can answer a given sub-topic.
+
+    `columns` may be a row mapping; when omitted, the check is against the known
+    column set the ingest defines.
+    """
+    required = _SUPPORTED_TOPICS.get(topic)
+    if not required:
+        return False
+    if columns is None:
+        return True
+    return all(col in columns for col in required)

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/pesticide_safety.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/pesticide_safety.py
@@ -63,6 +63,43 @@ def asks_for_safe_use_number(question: str) -> bool:
     return any(re.search(pattern, text) for pattern in _PHI_QUESTION_PATTERNS)
 
 
+def authoritative_answer_or_refusal(
+    *,
+    crop: str,
+    product_or_ingredient: str,
+    target_pest: str | None = None,
+    now_iso: str | None = None,
+    language: str = "ko",
+) -> dict[str, Any]:
+    """Return an authoritative PHI answer if the PSIS gateway can supply one.
+
+    Fail-closed: without a configured gateway, or on any lookup that does not yield a
+    verified PHI, this returns the refusal. A number is only ever surfaced when it
+    came from the authoritative registry — never from the local free text or a guess.
+    """
+    from .psis_gateway import fetch_safe_use_standard, is_configured
+
+    if not is_configured():
+        return safe_use_refusal(language=language)
+
+    standard = fetch_safe_use_standard(
+        crop=crop,
+        product_or_ingredient=product_or_ingredient,
+        target_pest=target_pest,
+        now_iso=now_iso,
+    )
+    if not standard.is_authoritative:
+        refusal = safe_use_refusal(language=language)
+        refusal["lookup"] = standard.to_dict()
+        return refusal
+
+    return {
+        "status": "authoritative_safe_use_standard",
+        "standard": standard.to_dict(),
+        "authoritative_sources": {"registry": PSIS_URL},
+    }
+
+
 def safe_use_refusal(*, language: str = "ko") -> dict[str, Any]:
     """The refusal payload for a safe-use-number question.
 

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/psis_gateway.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/psis_gateway.py
@@ -1,0 +1,181 @@
+"""RDA PSIS gateway: the authoritative source for pesticide safe-use standards.
+
+The local pesticide workbook has no PHI or application-count field, so those legally
+binding numbers must come from the authoritative registry — the RDA 농약안전정보시스템
+(PSIS), which publishes 안전사용기준 through public OpenAPI on data.go.kr. This module is
+that integration.
+
+It is **fail-closed by construction**: with no configured service key it does not guess,
+it reports ``unconfigured`` and the caller keeps refusing the number and pointing the grower
+to the registry (see :mod:`pesticide_safety`). A stale or failed lookup is likewise a
+refusal, never a fabricated figure. The LLM is never in this numeric path.
+
+The transport mirrors the existing KAMIS integration (:mod:`produce_prices`): an env-provided
+key, an httpx call with a bounded timeout, and a structured fallback on any failure.
+
+Configuration:
+    PSIS_SERVICE_KEY   data.go.kr service key (URL-decoded). Absent -> unconfigured.
+    PSIS_BASE_URL      override for the safe-use-standard endpoint (optional).
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/improvement_spec.md
+Registry: https://psis.rda.go.kr/  ·  OpenAPI: https://www.data.go.kr/data/15059306/openapi.do
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+#: data.go.kr safe-use-standard (농약안전사용지침) service, default endpoint.
+_DEFAULT_BASE_URL = "http://apis.data.go.kr/1390802/AgriPollutionService/getPesticideList"
+_TIMEOUT_SECONDS = 8.0
+
+#: How long a fetched standard may be treated as fresh before it must be re-fetched.
+#: Registrations change; a lease keeps a served number from silently going stale.
+AUTHORITY_LEASE_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class SafeUseStandard:
+    """A single authoritative safe-use record, or an unavailable result."""
+
+    status: str  # "ok" | "unconfigured" | "not_found" | "error"
+    product_name: str | None = None
+    crop: str | None = None
+    target_pest: str | None = None
+    pre_harvest_interval_days: int | None = None
+    max_applications: int | None = None
+    dilution: str | None = None
+    registration_status: str | None = None
+    source: str = "rda_psis"
+    fetched_at: str | None = None
+    detail: str | None = None
+
+    @property
+    def is_authoritative(self) -> bool:
+        return self.status == "ok" and self.pre_harvest_interval_days is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "product_name": self.product_name,
+            "crop": self.crop,
+            "target_pest": self.target_pest,
+            "pre_harvest_interval_days": self.pre_harvest_interval_days,
+            "max_applications": self.max_applications,
+            "dilution": self.dilution,
+            "registration_status": self.registration_status,
+            "source": self.source,
+            "fetched_at": self.fetched_at,
+            "detail": self.detail,
+        }
+
+
+def _service_key() -> str | None:
+    key = os.getenv("PSIS_SERVICE_KEY", "").strip()
+    return key or None
+
+
+def is_configured() -> bool:
+    """Whether a PSIS service key is present. Without it the gateway fails closed."""
+    return _service_key() is not None
+
+
+def _base_url() -> str:
+    return os.getenv("PSIS_BASE_URL", "").strip() or _DEFAULT_BASE_URL
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        text = str(value).strip()
+        return int(text) if text and text.lstrip("-").isdigit() else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_safe_use_standard(
+    *,
+    crop: str,
+    product_or_ingredient: str,
+    target_pest: str | None = None,
+    now_iso: str | None = None,
+    client: httpx.Client | None = None,
+) -> SafeUseStandard:
+    """Fetch the authoritative safe-use standard, or fail closed.
+
+    Returns ``status="unconfigured"`` when no key is set — the caller must then keep
+    refusing rather than presenting any number. ``now_iso`` is injected rather than
+    read from the clock so the call is deterministic and testable.
+    """
+    if not is_configured():
+        return SafeUseStandard(
+            status="unconfigured",
+            crop=crop,
+            detail="no PSIS_SERVICE_KEY; the authoritative registry was not queried",
+        )
+
+    params = {
+        "serviceKey": _service_key(),
+        "cropName": crop,
+        "pestName": target_pest or "",
+        "pesticideName": product_or_ingredient,
+        "numOfRows": "1",
+        "pageNo": "1",
+        "type": "json",
+    }
+    try:
+        owns_client = client is None
+        active = client or httpx.Client(timeout=_TIMEOUT_SECONDS)
+        try:
+            response = active.get(_base_url(), params=params)
+            response.raise_for_status()
+            payload = response.json()
+        finally:
+            if owns_client:
+                active.close()
+    except (httpx.HTTPError, ValueError) as exc:
+        return SafeUseStandard(
+            status="error",
+            crop=crop,
+            detail=f"PSIS lookup failed: {type(exc).__name__}",
+        )
+
+    record = _first_record(payload)
+    if record is None:
+        return SafeUseStandard(
+            status="not_found",
+            crop=crop,
+            detail="no matching safe-use record in PSIS",
+        )
+
+    return SafeUseStandard(
+        status="ok",
+        product_name=record.get("pesticideName") or product_or_ingredient,
+        crop=record.get("cropName") or crop,
+        target_pest=record.get("pestName") or target_pest,
+        pre_harvest_interval_days=_coerce_int(record.get("useSuittime")),
+        max_applications=_coerce_int(record.get("useNum")),
+        dilution=(str(record.get("dilutUnit")).strip() or None) if record.get("dilutUnit") else None,
+        registration_status=record.get("prlsGboonName"),
+        fetched_at=now_iso,
+    )
+
+
+def _first_record(payload: Any) -> dict[str, Any] | None:
+    """Pull the first item out of the data.go.kr response envelope, defensively."""
+    if not isinstance(payload, dict):
+        return None
+    body = payload.get("response", {}).get("body", {}) if "response" in payload else payload
+    items = body.get("items") if isinstance(body, dict) else None
+    if isinstance(items, dict):
+        items = items.get("item")
+    if isinstance(items, list) and items:
+        first = items[0]
+        return first if isinstance(first, dict) else None
+    if isinstance(items, dict):
+        return items
+    return None

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/rtr/internal_model_bridge.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/rtr/internal_model_bridge.py
@@ -150,6 +150,11 @@ class InternalModelContext:
     recent_events: list[dict[str, Any]]
     cost_per_kwh: float
     energy_estimator: EnergyEstimator
+    #: Where `cost_per_kwh` / `actual_area_m2` came from: "settings" when the grower
+    #: configured it, "default" when it is this module's fallback. A ₩ figure derived
+    #: from a ₩120/kWh placeholder must not be presented as the grower's own cost.
+    cost_per_kwh_source: str = "unknown"
+    actual_area_m2_source: str = "unknown"
 
 
 def build_internal_model_context(
@@ -161,6 +166,8 @@ def build_internal_model_context(
     recent_events: list[dict[str, Any]] | None = None,
     actual_area_m2: float | None = None,
     cost_per_kwh: float = 120.0,
+    cost_per_kwh_source: str = "unknown",
+    actual_area_m2_source: str = "unknown",
 ) -> InternalModelContext:
     normalized_snapshot = snapshot_record.get("normalized_snapshot", snapshot_record)
     state = normalized_snapshot.get("state", {})
@@ -397,4 +404,8 @@ def build_internal_model_context(
         recent_events=recent_events or [],
         cost_per_kwh=float(cost_per_kwh),
         energy_estimator=resolved_energy_estimator,
+        cost_per_kwh_source=cost_per_kwh_source,
+        actual_area_m2_source=(
+            actual_area_m2_source if actual_area_m2 is not None else "default"
+        ),
     )

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/rtr/scenario_runner.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/rtr/scenario_runner.py
@@ -226,6 +226,8 @@ def compute_rtr_temperature_sensitivity(
     base_candidate = _candidate_from_result(optimized_candidate)
     weights = _resolve_active_weights(context, optimization_inputs)
 
+    actual_area_m2 = float(getattr(context, "actual_area_m2", 0.0) or 0.0)
+
     def _finite_difference(
         *,
         target_name: str,
@@ -236,6 +238,8 @@ def compute_rtr_temperature_sensitivity(
         high_inputs: RTROptimizationInputs | None = None,
         extractor: Callable[[Mapping[str, Any]], float],
         control_name: str,
+        unit: str = "index/°C",
+        per_area: bool = False,
     ) -> dict[str, Any]:
         low_eval = _evaluate_candidate(
             context,
@@ -260,10 +264,13 @@ def compute_rtr_temperature_sensitivity(
         base_value = max(abs(extractor(base_eval)), 1e-9)
         derivative = (high_value - low_value) / (2 * perturbation_size)
         elasticity = (derivative / base_value) * perturbation_size
-        return {
+        row = {
             "control": control_name,
             "target": target_name,
             "derivative": round(derivative, 6),
+            # Units travel with the number. The absence of this field is how a
+            # kWh/m²/day gradient spent months being read as ₩/℃.
+            "unit": unit,
             "elasticity": round(elasticity, 6),
             "direction": "increase" if high_value >= low_value else "decrease",
             "trust_region": {"low": -perturbation_size, "high": perturbation_size},
@@ -272,6 +279,12 @@ def compute_rtr_temperature_sensitivity(
             "valid": True,
             "scenario_alignment": high_value >= low_value,
         }
+        if per_area:
+            # Per-m² is what the model computes; a grower asks about their house.
+            row["derivative_total"] = round(derivative * actual_area_m2, 6)
+            row["unit_total"] = unit.replace("/m2", "")
+            row["area_m2"] = actual_area_m2
+        return row
 
     screen_step = 5.0
     fan_step = 15.0
@@ -367,21 +380,82 @@ def compute_rtr_temperature_sensitivity(
             high_candidate=replace(base_candidate, screen_bias_pct=base_candidate.screen_bias_pct + screen_step),
             extractor=lambda payload: float(payload["objective_breakdown"]["disease_penalty"]),
         ),
+        # `objective_breakdown["heating_energy_cost"]` is named "cost" but holds
+        # kWh/m²/day (objective_terms.py). The currency field is `..._krw`, five
+        # lines away in the same dict. Reading the former and calling the result a
+        # cost derivative is how "온도 1℃ 올리면 난방비 얼마?" had no answer.
         _finite_difference(
             control_name="day_heating_min_temp_C",
-            target_name="heating_energy_cost",
+            target_name="heating_energy_kwh_m2_day",
             perturbation_size=step_c,
+            unit="kWh/m2/day/°C",
+            per_area=True,
             low_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C - step_c),
             high_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C + step_c),
             extractor=lambda payload: float(payload["objective_breakdown"]["heating_energy_cost"]),
         ),
         _finite_difference(
-            control_name="day_cooling_target_C",
-            target_name="cooling_energy_cost",
+            control_name="day_heating_min_temp_C",
+            target_name="heating_energy_cost_krw",
             perturbation_size=step_c,
+            unit="KRW/m2/day/°C",
+            per_area=True,
+            low_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C - step_c),
+            high_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C + step_c),
+            extractor=lambda payload: float(payload["objective_breakdown"]["heating_energy_cost_krw"]),
+        ),
+        _finite_difference(
+            control_name="night_heating_min_temp_C",
+            target_name="heating_energy_cost_krw",
+            perturbation_size=step_c,
+            unit="KRW/m2/day/°C",
+            per_area=True,
+            low_candidate=replace(base_candidate, night_heating_min_temp_C=base_candidate.night_heating_min_temp_C - step_c),
+            high_candidate=replace(base_candidate, night_heating_min_temp_C=base_candidate.night_heating_min_temp_C + step_c),
+            extractor=lambda payload: float(payload["objective_breakdown"]["heating_energy_cost_krw"]),
+        ),
+        _finite_difference(
+            control_name="day_cooling_target_C",
+            target_name="cooling_energy_cost_krw",
+            perturbation_size=step_c,
+            unit="KRW/m2/day/°C",
+            per_area=True,
             low_candidate=replace(base_candidate, day_cooling_target_C=base_candidate.day_cooling_target_C - step_c),
             high_candidate=replace(base_candidate, day_cooling_target_C=base_candidate.day_cooling_target_C + step_c),
-            extractor=lambda payload: float(payload["objective_breakdown"]["cooling_energy_cost"]),
+            extractor=lambda payload: float(payload["objective_breakdown"]["cooling_energy_cost_krw"]),
+        ),
+        _finite_difference(
+            control_name="day_cooling_target_C",
+            target_name="total_energy_cost_krw",
+            perturbation_size=step_c,
+            unit="KRW/m2/day/°C",
+            per_area=True,
+            low_candidate=replace(base_candidate, day_cooling_target_C=base_candidate.day_cooling_target_C - step_c),
+            high_candidate=replace(base_candidate, day_cooling_target_C=base_candidate.day_cooling_target_C + step_c),
+            extractor=lambda payload: float(payload["objective_breakdown"]["energy_cost_krw"]),
+        ),
+        # The other half of "온도 1℃ 올리면 …": node/truss development rate. The model
+        # already exists (node_target_engine); nothing was differentiating it against
+        # temperature. Deliberately wired here rather than by adding a node target to
+        # model_runtime's SUPPORTED_DERIVATIVE_TARGETS, whose scenario outputs carry
+        # no node state — that route would mean re-implementing the node engine.
+        _finite_difference(
+            control_name="day_heating_min_temp_C",
+            target_name="node_rate_day",
+            perturbation_size=step_c,
+            unit="node/day/°C",
+            low_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C - step_c),
+            high_candidate=replace(base_candidate, day_heating_min_temp_C=base_candidate.day_heating_min_temp_C + step_c),
+            extractor=lambda payload: float(payload["node_summary"]["predicted_rate_day"]),
+        ),
+        _finite_difference(
+            control_name="night_heating_min_temp_C",
+            target_name="node_rate_day",
+            perturbation_size=step_c,
+            unit="node/day/°C",
+            low_candidate=replace(base_candidate, night_heating_min_temp_C=base_candidate.night_heating_min_temp_C - step_c),
+            high_candidate=replace(base_candidate, night_heating_min_temp_C=base_candidate.night_heating_min_temp_C + step_c),
+            extractor=lambda payload: float(payload["node_summary"]["predicted_rate_day"]),
         ),
         _finite_difference(
             control_name="target_node_rate_day",
@@ -403,4 +477,15 @@ def compute_rtr_temperature_sensitivity(
         "crop": optimization_inputs.crop,
         "step_c": step_c,
         "sensitivities": sensitivities,
+        # A ₩ figure without its tariff and area is not an answer, it is a number.
+        # Any renderer showing `derivative_total` must show these next to it.
+        "assumptions": {
+            "cost_per_kwh": float(getattr(context, "cost_per_kwh", 0.0) or 0.0),
+            "cost_per_kwh_unit": "KRW/kWh",
+            "cost_per_kwh_source": str(getattr(context, "cost_per_kwh_source", "unknown")),
+            "actual_area_m2": actual_area_m2,
+            "actual_area_m2_source": str(
+                getattr(context, "actual_area_m2_source", "unknown")
+            ),
+        },
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,38 @@ from model_informed_greenhouse_dashboard.backend.app.services import (
 )
 
 
+def _write_minimal_pdf(path: Path, body_text: str) -> None:
+    """A minimal single-page PDF that pdfminer can extract text from.
+
+    The fixtures used to `.touch()` empty PDFs, which pdfminer cannot parse. A real
+    one-page PDF exercises the actual extraction + quality-gate path.
+    """
+    stream = f"BT /F1 12 Tf 72 700 Td ({body_text}) Tj ET".encode("latin-1", "replace")
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length %d >>\nstream\n%s\nendstream" % (len(stream), stream),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n" % index + obj + b"\nendobj\n"
+    xref_pos = len(out)
+    out += b"xref\n0 %d\n" % (len(objects) + 1)
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer\n<< /Root 1 0 R /Size %d >>\nstartxref\n%d\n%%%%EOF" % (
+        len(objects) + 1,
+        xref_pos,
+    )
+    path.write_bytes(bytes(out))
+
+
 def _write_telemetry_csv(path: Path, crop_label: str) -> None:
     path.write_text(
         "\n".join(
@@ -237,9 +269,15 @@ def synthetic_knowledge_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
 
     _write_telemetry_csv(data_dir / "Tomato_Env.CSV", "tomato")
     _write_telemetry_csv(data_dir / "Cucumber_Env.CSV", "cucumber")
+    _write_minimal_pdf(
+        data_dir / "농업기술길잡이-토마토.PDF",
+        "tomato cultivation guide environment management diagnosis harvest sample text",
+    )
+    _write_minimal_pdf(
+        data_dir / "농업기술길잡이-오이.PDF",
+        "cucumber cultivation guide environment management diagnosis harvest sample text",
+    )
     for filename in (
-        "농업기술길잡이-토마토.PDF",
-        "농업기술길잡이-오이.PDF",
         workbook_normalization.PESTICIDE_WORKBOOK,
         workbook_normalization.NUTRIENT_WORKBOOK,
     ):
@@ -273,6 +311,9 @@ def synthetic_knowledge_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
             "crop_scopes": ["tomato"],
             "asset_family": "manual",
             "source_type": "pdf",
+            # The synthetic PDF carries ASCII text (no Korean font embedding in a
+            # hand-built fixture), so the Hangul gate does not apply to it.
+            "expected_language": "any",
             "topic_hints": ["environment", "management", "diagnosis", "harvest"],
             "stage_hints": ["vegetative", "fruit_set", "harvest"],
         },
@@ -282,6 +323,7 @@ def synthetic_knowledge_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
             "crop_scopes": ["cucumber"],
             "asset_family": "manual",
             "source_type": "pdf",
+            "expected_language": "any",
             "topic_hints": ["environment", "management", "diagnosis", "harvest"],
             "stage_hints": ["vegetative", "fruit_set", "harvest"],
         },

--- a/tests/test_advisor_orchestration.py
+++ b/tests/test_advisor_orchestration.py
@@ -3046,3 +3046,90 @@ def test_build_environment_recommendation_response_keeps_legacy_keys_and_carries
     assert payload["machine_payload"]["environment_analysis"]["current_state"]["diagnosis"]
     assert payload["machine_payload"]["model_runtime"]["status"] == "ready"
     assert payload["machine_payload"]["model_runtime"]["scenario"]["baseline_outputs"]
+
+
+def _temperature_family_with_ladder() -> list[dict]:
+    """A control family whose bounded scenario only solves ±0.3/±0.9℃."""
+
+    def step(delta: float) -> dict:
+        return {
+            "applied_delta": delta,
+            "step_label": f"{delta:+g}℃",
+            "yield_delta_14d": delta * 3.0,
+            "canopy_delta_72h": delta * 0.3,
+            "source_sink_balance_delta": 0.0,
+            "energy_delta": delta * 0.6,
+            "confidence": 0.7,
+            "risk_flags": [],
+        }
+
+    return [
+        {
+            "control": "temperature_day",
+            "label": "주간 온도",
+            "unit": "℃",
+            "precision_mode": "bounded",
+            "recommended_step": step(0.3),
+            "steps": [step(-0.9), step(-0.3), step(0.3), step(0.9)],
+        }
+    ]
+
+
+def _focus_for(question: str) -> dict:
+    return advisor_orchestration._build_runtime_answer_focus(
+        messages=[{"role": "user", "content": question}],
+        recommendation_families=_temperature_family_with_ladder(),
+        language="ko",
+    )
+
+
+def test_out_of_range_what_if_returns_no_numbers() -> None:
+    """A +5℃ question must not be answered with the +0.9℃ result.
+
+    Regression guard for the council's most dangerous finding: the nearest-step
+    match had no bound, so a grower asking "온도를 5도 올리면?" was silently answered
+    with the model's +0.9℃ numbers, in fluent Korean, while the chat prompt forbade
+    any mention that a substitution had occurred.
+    """
+    focus = _focus_for("온도를 5도 올리면 어떻게 되나요")
+
+    assert focus["kind"] == "model_what_if_out_of_range"
+    assert focus["admissible"] is False
+    assert focus["effects"] == {}, "an out-of-range question has no calculated answer"
+    assert focus["matched_delta"] is None
+    assert focus["requested_delta"] == 5.0
+    assert focus["max_supported_delta"] == 0.9
+    assert "requested_delta_out_of_model_range" in focus["risk_flags"]
+    # The supported range must be stated so the grower can ask an answerable question.
+    assert "±0.9" in focus["summary"]
+
+
+def test_exactly_solved_delta_is_reported_as_the_users_request() -> None:
+    focus = _focus_for("온도를 0.9도 올리면?")
+
+    assert focus["kind"] == "model_what_if"
+    assert focus["matched_delta"] == 0.9
+    assert focus["matched_user_request"] is True
+    assert focus["delta_substituted"] is False
+    assert focus["effects"]["yield_delta_14d"] == pytest.approx(2.7)
+
+
+def test_in_range_but_unsolved_delta_discloses_the_substitution() -> None:
+    """+0.5℃ is inside the ladder but is not one of its steps."""
+    focus = _focus_for("온도를 0.5도 올리면?")
+
+    assert focus["kind"] == "model_what_if"
+    assert focus["matched_delta"] == 0.3
+    assert focus["delta_substituted"] is True
+    # It must not claim to have answered what was asked.
+    assert focus["matched_user_request"] is False
+    assert "computed_delta_differs_from_request" in focus["risk_flags"]
+    assert "주의: 요청은" in focus["summary"]
+
+
+def test_out_of_range_guard_does_not_disturb_unrequested_what_ifs() -> None:
+    focus = _focus_for("지금 상태 어때요")
+
+    assert focus["kind"] == "model_what_if"
+    assert focus["requested_delta"] is None
+    assert focus["effects"]

--- a/tests/test_answer_admission.py
+++ b/tests/test_answer_admission.py
@@ -223,3 +223,105 @@ def test_retrieval_context_injection_records_grounding_even_on_miss() -> None:
         {"status": "retrieval_unavailable"},
     )
     assert unavailable["knowledge"]["grounding_decision"] == "SOURCE_UNAVAILABLE"
+
+
+def test_marginal_change_facts_answer_the_canonical_question() -> None:
+    """"온도 1℃ 올리면 난방비/마디?" becomes admitted, composed facts.
+
+    This is the join of Phase 1 (the ₩/node derivatives) and Phase 2 (admission +
+    composition): the RTR sensitivity rows are admitted and rendered with a
+    whole-house total, a validity range, and tariff/area provenance.
+    """
+    from model_informed_greenhouse_dashboard.backend.app.services.answer_composer import (
+        build_marginal_change_facts,
+    )
+
+    payload = {
+        "sensitivities": [
+            {
+                "control": "day_heating_min_temp_C",
+                "target": "heating_energy_cost_krw",
+                "derivative": 0.1732,
+                "derivative_total": 572.6,
+                "unit": "KRW/m2/day/°C",
+                "unit_total": "KRW/day/°C",
+                "area_m2": 3305.8,
+                "perturbation_size": 0.3,
+                "trust_region": {"low": -0.3, "high": 0.3},
+                "scenario_alignment": True,
+            },
+            {
+                "control": "day_heating_min_temp_C",
+                "target": "node_rate_day",
+                "derivative": 0.0116,
+                "unit": "node/day/°C",
+                "perturbation_size": 0.3,
+                "trust_region": {"low": -0.3, "high": 0.3},
+                "scenario_alignment": True,
+            },
+            # A row that is not part of the canonical answer is ignored.
+            {
+                "control": "screen_bias_pct",
+                "target": "objective",
+                "derivative": 0.15,
+                "unit": "index/°C",
+                "scenario_alignment": True,
+            },
+        ],
+        "assumptions": {
+            "cost_per_kwh": 135.0,
+            "cost_per_kwh_source": "settings",
+            "actual_area_m2": 3305.8,
+            "actual_area_m2_source": "settings",
+        },
+    }
+
+    block = build_marginal_change_facts(payload)
+
+    quantities = {f["quantity"] for f in block["admitted_facts"]}
+    assert "난방비 변화" in quantities
+    assert "마디 발생속도 변화" in quantities
+    # The objective row is not a marginal-change target.
+    assert all(f["diagnostics"]["target"] != "objective" for f in block["admitted_facts"])
+
+    heating = next(f for f in block["admitted_facts"] if f["quantity"] == "난방비 변화")
+    # Whole-house total per 1°C, and its provenance.
+    assert "573 원" in heating["sentence"] or "572" in heating["sentence"]
+    assert "온실 전체" in heating["sentence"]
+    assert "요금 135" in heating["sentence"]
+    assert "면적 3305.8" in heating["sentence"]
+    assert "유효 범위" in heating["sentence"]
+
+    node = next(f for f in block["admitted_facts"] if f["quantity"] == "마디 발생속도 변화")
+    # A node rate does not depend on the tariff, so it must not carry one.
+    assert "요금" not in node["sentence"]
+    assert "node/day" in node["sentence"]
+
+
+def test_marginal_change_refuses_untrusted_derivative() -> None:
+    from model_informed_greenhouse_dashboard.backend.app.services.answer_composer import (
+        build_marginal_change_facts,
+    )
+
+    payload = {
+        "sensitivities": [
+            {
+                "control": "day_heating_min_temp_C",
+                "target": "heating_energy_cost_krw",
+                "derivative": 999.0,
+                "unit": "KRW/m2/day/°C",
+                "scenario_alignment": False,  # model does not trust it
+            },
+        ],
+        "assumptions": {
+            "cost_per_kwh": 135.0,
+            "cost_per_kwh_source": "settings",
+            "actual_area_m2": 3305.8,
+            "actual_area_m2_source": "settings",
+        },
+    }
+
+    block = build_marginal_change_facts(payload)
+    assert block["admitted_facts"] == []
+    assert len(block["refused_facts"]) == 1
+    assert "999" not in block["refused_facts"][0]["sentence"]

--- a/tests/test_answer_admission.py
+++ b/tests/test_answer_admission.py
@@ -1,0 +1,225 @@
+"""Admission is the existence proof of the design: an inadmissible number cannot be rendered."""
+
+from __future__ import annotations
+
+from model_informed_greenhouse_dashboard.backend.app.services.answer_admission import (
+    AdmissionStatus,
+    GroundingDecision,
+    admit_rtr_sensitivity_row,
+    admit_sensitivity,
+    grounding_decision,
+)
+from model_informed_greenhouse_dashboard.backend.app.services.answer_composer import (
+    compose_answer_facts_block,
+    compose_fact_sentence,
+)
+
+
+def _healthy_row(**overrides):
+    row = {
+        "control": "co2_setpoint_day",
+        "target": "predicted_yield_14d",
+        "derivative": 0.42,
+        "unit": "kg/ppm",
+        "perturbation_size": 80.0,
+        "trust_region": {"low": -120.0, "high": 120.0},
+        "scenario_alignment": True,
+        "nonlinearity_hint": "symmetric",
+        "local_confidence": 0.71,
+        "positive_response": 33.6,
+        "negative_response": -33.6,
+        "direction": "increase",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_healthy_row_is_admitted_with_its_number() -> None:
+    fact = admit_sensitivity(_healthy_row(), quantity="예상 수량")
+    assert fact.status is AdmissionStatus.ADMITTED
+    assert fact.admissible
+    assert fact.value == 0.42
+    assert fact.unit == "kg/ppm"
+
+
+def test_direction_conflict_is_refused_and_carries_no_number() -> None:
+    fact = admit_sensitivity(
+        _healthy_row(nonlinearity_hint="direction_conflict"), quantity="예상 수량"
+    )
+    assert fact.status is AdmissionStatus.DIRECTION_CONFLICT
+    assert not fact.admissible
+    assert fact.value is None
+
+
+def test_scenario_misalignment_is_refused() -> None:
+    fact = admit_sensitivity(_healthy_row(scenario_alignment=False), quantity="예상 수량")
+    assert fact.status is AdmissionStatus.DIRECTION_CONFLICT
+    assert fact.value is None
+
+
+def test_nonlinear_response_withdraws_the_slope() -> None:
+    fact = admit_sensitivity(_healthy_row(nonlinearity_hint="nonlinear"), quantity="예상 수량")
+    assert fact.status is AdmissionStatus.NONLINEAR
+    assert fact.value is None
+
+
+def test_low_confidence_is_refused() -> None:
+    fact = admit_sensitivity(
+        _healthy_row(local_confidence=0.2), quantity="예상 수량", min_confidence=0.4
+    )
+    assert fact.status is AdmissionStatus.LOW_CONFIDENCE
+    assert fact.value is None
+
+
+def test_missing_value_is_refused() -> None:
+    fact = admit_sensitivity(_healthy_row(derivative=None), quantity="예상 수량")
+    assert fact.status is AdmissionStatus.MISSING_VALUE
+    assert fact.value is None
+
+
+def test_currency_row_requires_provenance() -> None:
+    row = {
+        "control": "day_heating_min_temp_C",
+        "target": "heating_energy_cost_krw",
+        "derivative": 3.5,
+        "unit": "KRW/m2/day/°C",
+        "perturbation_size": 0.3,
+        "trust_region": {"low": -0.3, "high": 0.3},
+        "scenario_alignment": True,
+    }
+    refused = admit_rtr_sensitivity_row(row, assumptions=None)
+    assert refused.status is AdmissionStatus.MISSING_PROVENANCE
+    assert refused.value is None
+
+    admitted = admit_rtr_sensitivity_row(
+        row,
+        assumptions={
+            "cost_per_kwh": 135.0,
+            "cost_per_kwh_source": "settings",
+            "actual_area_m2": 3305.8,
+            "actual_area_m2_source": "settings",
+        },
+    )
+    assert admitted.status is AdmissionStatus.ADMITTED
+    assert admitted.value == 3.5
+    assert admitted.provenance["cost_per_kwh"] == 135.0
+
+
+def test_hostile_llm_cannot_surface_an_unadmitted_number() -> None:
+    """The existence proof.
+
+    Every dangerous state — direction conflict, low confidence, missing value,
+    missing provenance — is composed alongside a mock model that tries to emit a
+    plausible number. Not one inadmissible value may appear in the rendered block.
+    """
+    dangerous_rows = [
+        admit_sensitivity(_healthy_row(nonlinearity_hint="direction_conflict"), quantity="예상 수량"),
+        admit_sensitivity(_healthy_row(scenario_alignment=False), quantity="예상 수량"),
+        admit_sensitivity(_healthy_row(nonlinearity_hint="nonlinear"), quantity="예상 수량"),
+        admit_sensitivity(_healthy_row(local_confidence=0.1), quantity="예상 수량"),
+        admit_sensitivity(_healthy_row(derivative=None), quantity="예상 수량"),
+        admit_rtr_sensitivity_row(
+            {
+                "control": "day_heating_min_temp_C",
+                "target": "heating_energy_cost_krw",
+                "derivative": 99999.0,
+                "unit": "KRW/m2/day/°C",
+                "scenario_alignment": True,
+            },
+            assumptions=None,
+        ),
+    ]
+
+    block = compose_answer_facts_block(dangerous_rows)
+
+    # No admitted facts, so no rendered number.
+    assert block["admitted_facts"] == []
+    assert len(block["refused_facts"]) == len(dangerous_rows)
+
+    # The refused facts carry no value and no fabricated number in their sentence.
+    for entry in block["refused_facts"]:
+        assert entry["value"] is None
+        assert "99999" not in entry["sentence"]
+        assert "0.42" not in entry["sentence"]
+        # A refusal states why, it does not quote a figure.
+        assert any(
+            phrase in entry["sentence"]
+            for phrase in ("신뢰할 수 없어", "비선형", "신뢰도가 낮아", "계산된 값이 없", "요금·면적")
+        )
+
+
+def test_admitted_fact_renders_number_unit_and_validity() -> None:
+    fact = admit_sensitivity(_healthy_row(), quantity="예상 수량")
+    sentence = compose_fact_sentence(fact)
+    assert "0.42" in sentence
+    assert "kg/ppm" in sentence
+    assert "유효 범위" in sentence
+
+
+def test_default_tariff_is_disclosed_as_an_estimate() -> None:
+    fact = admit_rtr_sensitivity_row(
+        {
+            "control": "day_heating_min_temp_C",
+            "target": "heating_energy_cost_krw",
+            "derivative": 3.5,
+            "unit": "KRW/m2/day/°C",
+            "scenario_alignment": True,
+        },
+        assumptions={
+            "cost_per_kwh": 120.0,
+            "cost_per_kwh_source": "default",
+            "actual_area_m2": 3305.8,
+            "actual_area_m2_source": "default",
+        },
+    )
+    sentence = compose_fact_sentence(fact)
+    # A placeholder tariff must not read as the grower's own cost.
+    assert "추정 기본값" in sentence
+
+
+def test_grounding_decision_classification() -> None:
+    assert grounding_decision({"status": "ready", "evidence_cards": [{"x": 1}]}) is (
+        GroundingDecision.GROUNDED
+    )
+    assert grounding_decision({"status": "ready", "evidence_cards": []}) is (
+        GroundingDecision.NO_MATCH
+    )
+    assert grounding_decision({"status": "retrieval_unavailable"}) is (
+        GroundingDecision.SOURCE_UNAVAILABLE
+    )
+    assert grounding_decision({"status": "database_missing"}) is (
+        GroundingDecision.SOURCE_UNAVAILABLE
+    )
+    assert grounding_decision(None) is GroundingDecision.NO_MATCH
+
+
+def test_retrieval_context_injection_records_grounding_even_on_miss() -> None:
+    """A zero-evidence answer must be distinguishable from a grounded one.
+
+    Regression guard for the silent-failure defect: the old inject helper returned
+    the dashboard unchanged whenever status != "ready", so nothing downstream could
+    tell that retrieval had found nothing.
+    """
+    from model_informed_greenhouse_dashboard.backend.app.services import (
+        advisor_orchestration,
+    )
+
+    grounded = advisor_orchestration._inject_advisor_retrieval_context(
+        {"currentData": {}},
+        {"status": "ready", "llm_context": {"evidence_cards": [{"evidence_excerpt": "x"}]}},
+    )
+    assert grounded["knowledge"]["grounding_decision"] == "GROUNDED"
+    assert grounded["knowledge"]["advisor_retrieval_context"]["evidence_cards"]
+
+    missed = advisor_orchestration._inject_advisor_retrieval_context(
+        {"currentData": {}},
+        {"status": "ready", "llm_context": {"evidence_cards": []}},
+    )
+    assert missed["knowledge"]["grounding_decision"] == "NO_MATCH"
+    assert "advisor_retrieval_context" not in missed["knowledge"]
+
+    unavailable = advisor_orchestration._inject_advisor_retrieval_context(
+        {"currentData": {}},
+        {"status": "retrieval_unavailable"},
+    )
+    assert unavailable["knowledge"]["grounding_decision"] == "SOURCE_UNAVAILABLE"

--- a/tests/test_corpus_quarantine.py
+++ b/tests/test_corpus_quarantine.py
@@ -90,3 +90,52 @@ def test_quarantine_clause_actually_excludes_rows_in_sqlite() -> None:
     connection.close()
 
     assert [row[0] for row in rows] == [1, 6], "quarantined documents leaked into results"
+
+
+def _pages_from_text(text: str) -> list[str]:
+    return [text]
+
+
+def test_quality_gate_passes_korean_prose() -> None:
+    from model_informed_greenhouse_dashboard.backend.app.services.pdf_quality import (
+        assess_document,
+    )
+
+    korean = "토마토 생육 관리와 환경 제어에 관한 실제 한국어 본문 문장입니다. " * 5
+    result = assess_document(_pages_from_text(korean), expected_language="ko")
+    assert result.passes
+    assert result.hangul_share > 0.20
+
+
+def test_quality_gate_fails_japanese_text_for_a_korean_document() -> None:
+    """The compendia's recovered text is Japanese; a ko-expected doc must fail on it."""
+    from model_informed_greenhouse_dashboard.backend.app.services.pdf_quality import (
+        assess_document,
+    )
+
+    japanese = "果重は地温が高めで気温が組合わせのとき最もすぐれている。生理障害の防止策。" * 5
+    result = assess_document(_pages_from_text(japanese), expected_language="ko")
+    assert not result.passes
+    assert result.hangul_share == 0.0
+    assert "Hangul share" in result.reason
+
+
+def test_quality_gate_ignores_language_for_structured_documents() -> None:
+    from model_informed_greenhouse_dashboard.backend.app.services.pdf_quality import (
+        assess_document,
+    )
+
+    latin = "product active_ingredient FRAC group registration status " * 5
+    result = assess_document(_pages_from_text(latin), expected_language="any")
+    assert result.passes
+
+
+def test_quality_gate_flags_junk_characters() -> None:
+    from model_informed_greenhouse_dashboard.backend.app.services.pdf_quality import (
+        assess_document,
+    )
+
+    junk = "����� 토마토 �����" * 20
+    result = assess_document(_pages_from_text(junk), expected_language="ko")
+    assert not result.passes
+    assert "junk" in result.reason

--- a/tests/test_corpus_quarantine.py
+++ b/tests/test_corpus_quarantine.py
@@ -1,0 +1,92 @@
+"""Corpus quarantine must be structurally impossible for a caller to bypass."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from model_informed_greenhouse_dashboard.backend.app.services import knowledge_database
+from model_informed_greenhouse_dashboard.backend.app.services.corpus_quarantine import (
+    QUARANTINED_ASSET_FAMILIES,
+    QUARANTINED_FILENAMES,
+    is_quarantined,
+    quarantine_filter_sql,
+    quarantine_reasons,
+)
+
+
+def test_orphaned_wiki_families_are_quarantined() -> None:
+    # The LLM Wiki was removed from main on 2026-07-05 for PII/source exposure,
+    # but its rows outlived the ingest code in already-built indexes.
+    assert is_quarantined(asset_family="wiki_page")
+    assert is_quarantined(asset_family="wiki_case")
+    assert is_quarantined(asset_family="WIKI_PAGE")
+    assert not is_quarantined(asset_family="manual")
+
+
+def test_japanese_compendia_are_quarantined() -> None:
+    # 農業技術大系: Japanese-language books; agronomic transfer unverified and
+    # the 農文協 licence is unresolved.
+    assert is_quarantined(filename="농업기술대계_토마토편.pdf")
+    assert is_quarantined(filename="오이_농업기술대계.pdf")
+    assert not is_quarantined(filename="농업기술길잡이-토마토.PDF")
+
+
+def test_every_quarantine_entry_states_a_reason() -> None:
+    reasons = quarantine_reasons()
+    for entry in (*QUARANTINED_ASSET_FAMILIES, *QUARANTINED_FILENAMES):
+        assert reasons.get(entry), f"quarantined without a stated reason: {entry}"
+
+
+def test_quarantine_clause_is_never_empty() -> None:
+    # An empty clause would be silently treated as "nothing to exclude".
+    sql, params = quarantine_filter_sql()
+    assert sql.strip()
+    assert "NOT IN" in sql
+    assert params
+
+
+def test_document_filter_always_carries_the_quarantine_clause() -> None:
+    """The guarantee: no caller-supplied filter can opt out of quarantine."""
+    for crop, filters in (
+        (None, None),
+        (None, {}),
+        ("tomato", None),
+        ("tomato", {"source_types": ["pdf", "markdown"]}),
+        # A caller explicitly asking for quarantined content still must not get it.
+        ("tomato", {"asset_families": ["wiki_page"]}),
+        ("cucumber", {"asset_families": ["wiki_case"], "source_types": ["markdown"]}),
+    ):
+        where_sql, params = knowledge_database._document_filter_sql(crop=crop, filters=filters)
+        assert "asset_family" in where_sql and "NOT IN" in where_sql, (
+            f"quarantine clause missing for crop={crop!r} filters={filters!r}"
+        )
+        for family in QUARANTINED_ASSET_FAMILIES:
+            assert family in params
+        for filename in QUARANTINED_FILENAMES:
+            assert filename.lower() in params
+
+
+def test_quarantine_clause_actually_excludes_rows_in_sqlite() -> None:
+    """Execute the real clause against a real SQLite table."""
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE kd (document_id INTEGER, asset_family TEXT, filename TEXT)"
+    )
+    connection.executemany(
+        "INSERT INTO kd VALUES (?, ?, ?)",
+        [
+            (1, "manual", "농업기술길잡이-토마토.PDF"),
+            (2, "wiki_page", "001_작물기초.md"),
+            (3, "wiki_case", "case_001.md"),
+            (4, "manual", "농업기술대계_토마토편.pdf"),
+            (5, "manual", "오이_농업기술대계.pdf"),
+            (6, "pesticide_workbook", "농약 솔루션_260326_v1.xlsx"),
+        ],
+    )
+    where_sql, params = quarantine_filter_sql(document_alias="kd")
+    rows = connection.execute(
+        f"SELECT document_id FROM kd WHERE {where_sql} ORDER BY document_id", params
+    ).fetchall()
+    connection.close()
+
+    assert [row[0] for row in rows] == [1, 6], "quarantined documents leaked into results"

--- a/tests/test_knowledge_query.py
+++ b/tests/test_knowledge_query.py
@@ -103,7 +103,10 @@ def test_query_knowledge_database_routes_environment_queries_to_pdf_and_csv(
 
     assert payload["routing"]["intent"] == "environment_control"
     assert payload["applied_filters"]["topic_major"] == "environment"
-    assert payload["applied_filters"]["source_types"] == ["pdf", "csv"]
+    # `markdown` is in the allowlist so a governed curated-wiki source stays
+    # reachable; `xlsx` must stay out so environment queries never drift into the
+    # pesticide/nutrient workbooks.
+    assert payload["applied_filters"]["source_types"] == ["pdf", "csv", "markdown"]
     assert payload["results"]
     assert payload["results"][0]["document"]["source_type"] in {"pdf", "csv"}
 
@@ -125,11 +128,11 @@ def test_query_knowledge_database_keeps_symptom_and_work_queries_broad_enough(
 
     assert symptom_payload["routing"]["intent"] == "disease_pest"
     assert symptom_payload["routing"]["sub_intent"] == "symptom_to_action"
-    assert symptom_payload["applied_filters"]["source_types"] == ["pdf", "xlsx"]
+    assert symptom_payload["applied_filters"]["source_types"] == ["pdf", "xlsx", "markdown"]
     assert "asset_families" not in symptom_payload["applied_filters"]
 
     assert work_payload["routing"]["intent"] == "cultivation_work"
-    assert work_payload["applied_filters"]["source_types"] == ["pdf"]
+    assert work_payload["applied_filters"]["source_types"] == ["pdf", "markdown"]
     assert "topic_major" not in work_payload["applied_filters"]
 
 
@@ -140,7 +143,7 @@ def test_query_knowledge_database_routes_cucumber_cultivation_terms_away_from_pe
 
     route = route_knowledge_query("오이재배방법")
     assert route["intent"] == "cultivation_work"
-    assert route["search_filters"]["source_types"] == ["pdf"]
+    assert route["search_filters"]["source_types"] == ["pdf", "markdown"]
     assert {"오이", "재배", "방법"}.issubset(set(route["query_terms"]))
 
     payload = knowledge_database.query_knowledge_database(
@@ -160,7 +163,7 @@ def test_query_knowledge_database_routes_cucumber_cultivation_terms_away_from_pe
     )
 
     assert payload["routing"]["intent"] == "cultivation_work"
-    assert payload["applied_filters"]["source_types"] == ["pdf"]
+    assert payload["applied_filters"]["source_types"] == ["pdf", "markdown"]
     assert payload["returned_count"] >= 1
     assert all(
         result["document"]["asset_family"] != "pesticide_workbook"
@@ -172,7 +175,7 @@ def test_query_knowledge_database_routes_cucumber_cultivation_terms_away_from_pe
     assert short_payload["results"][0]["document"]["asset_family"] != "pesticide_workbook"
 
     assert pesticide_payload["routing"]["intent"] == "disease_pest"
-    assert pesticide_payload["applied_filters"]["source_types"] == ["pdf", "xlsx"]
+    assert pesticide_payload["applied_filters"]["source_types"] == ["pdf", "xlsx", "markdown"]
 
 
 def test_query_knowledge_database_database_missing_still_reports_routing(
@@ -345,3 +348,39 @@ def test_knowledge_query_endpoint_bootstraps_catalog_when_database_is_empty(
     assert payload["query_status"] == "ready"
     assert payload["returned_count"] == 1
     assert calls["rebuild"] == 1
+
+
+def test_naturally_phrased_korean_physiology_questions_route_to_crop_physiology() -> None:
+    """Korean is agglutinative: the bare keyword never appears in a real question.
+
+    Before 2026-07-17 all four of these fell through to `general_chat` because
+    `_KOREAN_COMPOUND_TERMS` held no physiology vocabulary, which left the
+    `crop_physiology` profile — and its topic filter and rerank profile —
+    unreachable for anything a grower would actually type.
+    """
+    questions = [
+        "토마토 생리장해 원인과 대책",
+        "마디 증가 속도는 온도에 따라 어떻게 달라지나요",
+        "광합성이 잘 안되는 것 같아요",
+        "착과율이 떨어집니다",
+        "화방 출현이 늦어요",
+        "초세가 너무 강합니다",
+    ]
+    for question in questions:
+        route = route_knowledge_query(question)
+        assert route["intent"] == "crop_physiology", f"{question!r} -> {route['intent']}"
+        assert route["rerank_profile"] == "physiology"
+
+
+def test_physiology_vocabulary_does_not_steal_other_intents() -> None:
+    """The added compounds must not pull unrelated questions into physiology."""
+    for question, expected in (
+        ("흰가루병 방제 농약과 안전사용기준", "disease_pest"),
+        ("양액 처방 EC 보정", "nutrient_recipe"),
+        ("온도 습도 환기 설정", "environment_control"),
+        ("수확 시기와 출하 등급", "harvest_market"),
+        ("적엽 유인 작업 체크리스트", "cultivation_work"),
+        ("오이재배방법", "cultivation_work"),
+    ):
+        route = route_knowledge_query(question)
+        assert route["intent"] == expected, f"{question!r} -> {route['intent']}"

--- a/tests/test_model_runtime_scenario_sensitivity.py
+++ b/tests/test_model_runtime_scenario_sensitivity.py
@@ -284,3 +284,38 @@ def test_model_sensitivity_endpoint_reports_positive_co2_derivative(
     assert payload["sensitivities"][0]["direction"] == "increase"
     assert payload["sensitivities"][0]["derivative"] > 0
     assert payload["sensitivities"][0]["scenario_alignment"] is True
+
+
+def test_energy_target_is_not_advertised_as_money() -> None:
+    """The dimensionless index must not be named or rendered as currency.
+
+    `energy_cost_pred` is `horizon_days * (0.75 + energy_rate_delta)` — a unitless
+    composite that is never multiplied by kWh or `cost_per_kwh`. Exposing its
+    gradient under the name `energy_cost_72h` invited every later reader, human or
+    model, to read ₩/℃ off an index gradient. The real currency derivative lives in
+    the RTR subsystem.
+    """
+    from model_informed_greenhouse_dashboard.backend.app.services.model_runtime import (
+        sensitivity_engine,
+    )
+
+    assert "energy_load_index_72h" in sensitivity_engine.SUPPORTED_DERIVATIVE_TARGETS
+    assert "energy_cost_72h" not in sensitivity_engine.SUPPORTED_DERIVATIVE_TARGETS
+    assert "energy_load_index_72h" in sensitivity_engine.NON_MONETARY_TARGETS
+
+    # No advertised target may claim to be a cost.
+    for target in sensitivity_engine.SUPPORTED_DERIVATIVE_TARGETS:
+        assert "cost" not in target, f"{target} reads as money but is not denominated in it"
+
+
+def test_retired_energy_target_name_still_resolves() -> None:
+    """Stored/scripted callers using the old name must not break."""
+    from model_informed_greenhouse_dashboard.backend.app.services.model_runtime import (
+        sensitivity_engine,
+    )
+
+    assert sensitivity_engine.resolve_derivative_target("energy_cost_72h") == (
+        "energy_load_index_72h"
+    )
+    # A name that was never valid still fails.
+    assert sensitivity_engine.resolve_derivative_target("nonsense") == "nonsense"

--- a/tests/test_openai_ai.py
+++ b/tests/test_openai_ai.py
@@ -179,13 +179,77 @@ def test_openai_helper_mentions_precision_runtime_contract_when_present(
     )
 
     prompt = fake_client.responses.calls[0]["input"][0]["content"]
-    # The model runtime is provided as private context the reply can lean on.
+    # The model runtime is the context the reply's numbers must come from.
     assert "answer_focus" in prompt
     assert "control_precision_matrix" in prompt
     assert "model_runtime" in prompt
-    # Conversational guardrails: never cite sources, never invent missing values.
-    assert "인용" in prompt or "출처" in prompt
-    assert "없는 값" in prompt
+    # Numeric-integrity guardrails. Before 2026-07-17 this prompt instead forbade
+    # citing sources and structuring the answer, which suppressed exactly the
+    # quantitative register the advisor exists to provide.
+    assert "그대로 가져와야" in prompt, "numbers must be taken from the model verbatim"
+    assert "외삽하지" in prompt, "a small step must not be extrapolated to a larger one"
+    assert "추정하지" in prompt, "missing/unreliable values must be surfaced, not estimated"
+
+
+def test_chat_system_prompt_requires_the_expert_register(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prompt must demand units and a validity range, and must not gag the model.
+
+    Regression guard for commit 74c3fb1, which optimized the conversational register
+    and paid for it in substance: it told the model never to mention sources and to
+    "just speak as if you already knew", which is a prompt-level ban on the expert
+    answer the user was asking for.
+    """
+    prompt = ai_service._chat_system_prompt("tomato", "ko")
+
+    # Required: the quantitative register.
+    assert "단위" in prompt
+    assert "범위" in prompt
+    assert "모른다" in prompt
+    assert "만들어내지" in prompt
+
+    # Still conversational — the natural-chat UX is not the defect.
+    assert "리포트 구조" in prompt
+
+    # Forbidden: the gag clauses that caused the regression.
+    assert "절대 언급하지 마세요" not in prompt
+    assert "원래 아는 것처럼" not in prompt
+
+
+def test_chat_evidence_is_transmitted_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Excerpts belong in the grounding block, not also in the dashboard JSON."""
+    fake_client = _FakeOpenAI()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(ai_service, "OpenAI", lambda: fake_client)
+
+    marker = "붕소 결핍은 생장점 괴사로 나타난다"
+    dashboard = {
+        "currentData": {"temperature": 22.5},
+        "knowledge": {
+            "advisor_retrieval_context": {
+                "status": "ready",
+                "evidence_cards": [
+                    {"topic_major": "physiology", "evidence_excerpt": marker},
+                ],
+            }
+        },
+    }
+
+    ai_service.generate_chat_reply(
+        crop="tomato",
+        messages=[{"role": "user", "content": "생리장해 원인이 뭔가요"}],
+        dashboard=dashboard,
+        language="ko",
+        model="gpt-5.4-mini",
+    )
+
+    prompt = fake_client.responses.calls[0]["input"][0]["content"]
+    assert prompt.count(marker) == 1, "evidence was transmitted more than once"
+    # The caller's dashboard must not be mutated.
+    assert dashboard["knowledge"]["advisor_retrieval_context"]["evidence_cards"]
 
 
 def test_build_advisory_display_payload_accepts_locale_aware_korean_headings() -> None:

--- a/tests/test_pesticide_safety.py
+++ b/tests/test_pesticide_safety.py
@@ -1,0 +1,91 @@
+"""A legally-binding pesticide number the schema can't supply must be refused, not guessed."""
+
+from __future__ import annotations
+
+from model_informed_greenhouse_dashboard.backend.app.services.pesticide_safety import (
+    PSIS_URL,
+    asks_for_safe_use_number,
+    safe_use_refusal,
+    schema_supports,
+)
+
+
+def test_phi_and_safe_use_questions_are_detected() -> None:
+    for question in (
+        "토마토 흰가루병 수확 전 며칠 전까지 쓸 수 있나요",
+        "이 약 안전사용기준 알려줘",
+        "사용 횟수 제한이 어떻게 되나요",
+        "몇 번까지 칠 수 있어요",
+        "희석 배수는 얼마인가요",
+        "what is the PHI for this fungicide",
+        "pre-harvest interval?",
+    ):
+        assert asks_for_safe_use_number(question), question
+
+
+def test_non_safe_use_pesticide_questions_are_not_gated() -> None:
+    for question in (
+        "흰가루병에 어떤 약이 등록돼 있어요",
+        "교호방제 어떻게 짜나요",
+        "이 두 약 섞어도 되나요",
+        "오늘 온도 어때요",
+    ):
+        assert not asks_for_safe_use_number(question), question
+
+
+def test_refusal_points_to_the_authoritative_registry() -> None:
+    refusal = safe_use_refusal(language="ko")
+    assert refusal["status"] == "refused_safe_use_standard"
+    assert PSIS_URL in refusal["message"]
+    assert "psis.rda.go.kr" in refusal["authoritative_sources"]["registry"]
+    # It must offer what the schema *can* answer rather than a flat "no".
+    assert set(refusal["supported_topics"]) == {"rotation", "mixing", "registration"}
+
+
+def test_refusal_message_contains_no_fabricated_number() -> None:
+    message = safe_use_refusal(language="ko")["message"]
+    # A refusal for a legally-binding figure must not itself state a day count.
+    assert "일수" in message or "수확" in message  # it names the concept
+    # but never a concrete PHI like "7일" / "14일".
+    import re
+
+    assert not re.search(r"\d+\s*일", message)
+
+
+def test_schema_supports_only_what_the_columns_carry() -> None:
+    assert schema_supports("rotation")
+    assert schema_supports("mixing")
+    assert schema_supports("registration")
+    # No PHI/application-count topic is supported, because there is no column.
+    assert not schema_supports("phi")
+    assert not schema_supports("application_count")
+    # A row missing the required column fails the check.
+    assert not schema_supports("rotation", columns={"product_name": "x"})
+    assert schema_supports("rotation", columns={"moa_code_group": "FRAC 3"})
+
+
+def test_chat_refuses_phi_before_any_llm_call(monkeypatch) -> None:
+    """The gate must fire deterministically, without reaching the model."""
+    from model_informed_greenhouse_dashboard.backend.app.services import (
+        advisor_orchestration,
+    )
+
+    called = {"llm": False}
+
+    def _boom(**kwargs):
+        called["llm"] = True
+        raise AssertionError("the LLM must not be called for a refused PHI question")
+
+    monkeypatch.setattr(advisor_orchestration, "generate_chat_reply", _boom)
+
+    response = advisor_orchestration.build_advisor_chat_response(
+        crop="tomato",
+        messages=[{"role": "user", "content": "흰가루병 약 수확 전 며칠 전까지 쓸 수 있어요"}],
+        dashboard={"currentData": {}},
+        language="ko",
+    )
+
+    assert called["llm"] is False
+    assert response["machine_payload"]["answer_gate"] == "pesticide_safe_use_refusal"
+    assert "psis.rda.go.kr" in response["machine_payload"]["authoritative_sources"]["registry"]
+    assert PSIS_URL in response["text"]

--- a/tests/test_psis_gateway.py
+++ b/tests/test_psis_gateway.py
@@ -1,0 +1,117 @@
+"""The PSIS gateway must fail closed: no key, no guess."""
+
+from __future__ import annotations
+
+import httpx
+
+from model_informed_greenhouse_dashboard.backend.app.services import psis_gateway
+from model_informed_greenhouse_dashboard.backend.app.services.pesticide_safety import (
+    authoritative_answer_or_refusal,
+)
+
+
+def test_unconfigured_gateway_does_not_query_or_guess(monkeypatch) -> None:
+    monkeypatch.delenv("PSIS_SERVICE_KEY", raising=False)
+    assert not psis_gateway.is_configured()
+
+    result = psis_gateway.fetch_safe_use_standard(
+        crop="tomato", product_or_ingredient="포룸"
+    )
+    assert result.status == "unconfigured"
+    assert result.pre_harvest_interval_days is None
+    assert not result.is_authoritative
+
+
+def test_authoritative_answer_falls_back_to_refusal_without_a_key(monkeypatch) -> None:
+    monkeypatch.delenv("PSIS_SERVICE_KEY", raising=False)
+    answer = authoritative_answer_or_refusal(
+        crop="tomato", product_or_ingredient="포룸", language="ko"
+    )
+    assert answer["status"] == "refused_safe_use_standard"
+    assert "psis.rda.go.kr" in answer["authoritative_sources"]["registry"]
+
+
+def test_gateway_parses_a_data_go_kr_record(monkeypatch) -> None:
+    monkeypatch.setenv("PSIS_SERVICE_KEY", "test-key")
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "response": {
+                    "body": {
+                        "items": {
+                            "item": [
+                                {
+                                    "pesticideName": "포룸",
+                                    "cropName": "토마토",
+                                    "pestName": "역병",
+                                    "useSuittime": "3",
+                                    "useNum": "4",
+                                    "dilutUnit": "2000배",
+                                    "prlsGboonName": "등록",
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    with httpx.Client(transport=transport) as client:
+        result = psis_gateway.fetch_safe_use_standard(
+            crop="토마토",
+            product_or_ingredient="포룸",
+            target_pest="역병",
+            now_iso="2026-07-18T00:00:00Z",
+            client=client,
+        )
+
+    assert result.status == "ok"
+    assert result.is_authoritative
+    assert result.pre_harvest_interval_days == 3
+    assert result.max_applications == 4
+    assert result.dilution == "2000배"
+    assert result.fetched_at == "2026-07-18T00:00:00Z"
+
+
+def test_gateway_returns_refusal_details_on_http_error(monkeypatch) -> None:
+    monkeypatch.setenv("PSIS_SERVICE_KEY", "test-key")
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    transport = httpx.MockTransport(_handler)
+    with httpx.Client(transport=transport) as client:
+        result = psis_gateway.fetch_safe_use_standard(
+            crop="토마토", product_or_ingredient="포룸", client=client
+        )
+    assert result.status == "error"
+    assert not result.is_authoritative
+
+
+def test_authoritative_answer_surfaces_only_a_registry_number(monkeypatch) -> None:
+    """When configured and the lookup succeeds, the number is the registry's."""
+    monkeypatch.setenv("PSIS_SERVICE_KEY", "test-key")
+
+    def _fake_fetch(**kwargs):
+        return psis_gateway.SafeUseStandard(
+            status="ok",
+            product_name="포룸",
+            crop="토마토",
+            pre_harvest_interval_days=3,
+            max_applications=4,
+            fetched_at="2026-07-18T00:00:00Z",
+        )
+
+    monkeypatch.setattr(
+        "model_informed_greenhouse_dashboard.backend.app.services.psis_gateway."
+        "fetch_safe_use_standard",
+        _fake_fetch,
+    )
+    answer = authoritative_answer_or_refusal(
+        crop="토마토", product_or_ingredient="포룸"
+    )
+    assert answer["status"] == "authoritative_safe_use_standard"
+    assert answer["standard"]["pre_harvest_interval_days"] == 3

--- a/tests/test_rtr_optimizer.py
+++ b/tests/test_rtr_optimizer.py
@@ -7,6 +7,7 @@ import types
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 from fastapi.testclient import TestClient
 
 from model_informed_greenhouse_dashboard import get_app
@@ -1135,14 +1136,21 @@ def test_sensitivity_objective_derivative_respects_energy_option(monkeypatch) ->
     def _fake_eval(**kwargs):
         captured_weights.append(dict(kwargs["weights"]))
         heating_weight = float(kwargs["weights"].get("heating", 0.0))
+        # Mirrors the shape `build_objective_terms` actually returns, including the
+        # `_krw` currency fields that sit alongside the identically-named kWh ones
+        # and the node summary the node-rate derivative reads.
         return {
             "objective_value": heating_weight,
             "flux_projection": {"carbon_margin": 1.0},
+            "node_summary": {"predicted_rate_day": 0.0},
             "objective_breakdown": {
                 "humidity_risk_penalty": 0.0,
                 "disease_penalty": 0.0,
                 "heating_energy_cost": 0.0,
                 "cooling_energy_cost": 0.0,
+                "heating_energy_cost_krw": 0.0,
+                "cooling_energy_cost_krw": 0.0,
+                "energy_cost_krw": 0.0,
                 "labor_cost": 0.0,
             },
         }
@@ -2096,3 +2104,128 @@ def test_rtr_calibration_save_route_persists_windows_and_refreshes_profile(
         assert profiles_response.json()["profiles"]["Cucumber"]["calibration"]["mode"] == "fitted"
     finally:
         backend_main.app_state["cucumber"]["df_env"] = original_df_env
+
+
+def _sensitivity_rows_for(*, cost_per_kwh: float, actual_area_m2: float) -> dict:
+    """Run the RTR temperature sensitivity with a given tariff and area.
+
+    The candidate sits at 22℃, above the fixture's `heating_set_C` of 19℃. Below
+    that the heating demand is flat, so a ±0.3℃ probe would return a legitimately
+    zero derivative and prove nothing about the currency wiring.
+    """
+    services = _load_optimizer_rtr_services()
+    context = _fake_context(
+        crop="tomato",
+        par_umol_m2_s=860.0,
+        co2_ppm=760.0,
+        t_air_c=20.0,
+        outside_t_c=8.0,
+        source_capacity=1.02,
+        sink_demand=0.88,
+        fruit_load=10.5,
+        source_sink_balance=0.12,
+    )
+    context.cost_per_kwh = cost_per_kwh
+    context.actual_area_m2 = actual_area_m2
+    optimization_inputs = _optimization_inputs(
+        services,
+        "tomato",
+        target_node_development_per_day=0.12,
+    )
+    optimized_candidate = {
+        "controls": {
+            "day_heating_min_temp_C": 22.0,
+            "night_heating_min_temp_C": 21.4,
+            "day_cooling_target_C": 27.0,
+            "night_cooling_target_C": 24.0,
+            "vent_bias_C": 0.0,
+            "screen_bias_pct": 0.0,
+            "circulation_fan_pct": 35.0,
+            "co2_target_ppm": 760.0,
+            "dehumidification_bias": 0.0,
+            "fogging_or_evap_cooling_intensity": 0.0,
+        }
+    }
+    payload = services.scenario_runner.compute_rtr_temperature_sensitivity(
+        context=context,
+        optimization_inputs=optimization_inputs,
+        optimized_candidate=optimized_candidate,
+    )
+    rows: dict = {
+        (row["control"], row["target"]): row for row in payload["sensitivities"]
+    }
+    rows["__assumptions__"] = payload["assumptions"]
+    return rows
+
+
+def test_currency_derivative_scales_exactly_with_tariff_and_area() -> None:
+    """The council's kill-test for "the model is there, only the wiring is wrong".
+
+    If the ₩ derivative does not scale exactly with the tariff, or the total does not
+    scale exactly with area while per-m² and node rate stay put, then the currency
+    path is not a wiring fix and the energy model itself needs work first.
+    """
+    base = _sensitivity_rows_for(cost_per_kwh=135.0, actual_area_m2=3305.8)
+    double_tariff = _sensitivity_rows_for(cost_per_kwh=270.0, actual_area_m2=3305.8)
+    double_area = _sensitivity_rows_for(cost_per_kwh=135.0, actual_area_m2=6611.6)
+
+    key = ("day_heating_min_temp_C", "heating_energy_cost_krw")
+    node_key = ("day_heating_min_temp_C", "node_rate_day")
+
+    base_krw = base[key]["derivative"]
+    assert base_krw != 0.0, "a temperature step must move heating cost"
+
+    # Tariff x2 -> ₩ derivative x2 exactly; node rate is physiology, not price.
+    assert double_tariff[key]["derivative"] == pytest.approx(base_krw * 2.0, rel=1e-9)
+    assert double_tariff[node_key]["derivative"] == pytest.approx(
+        base[node_key]["derivative"], rel=1e-9
+    )
+
+    # Area x2 -> total ₩ x2, per-m² unchanged, node rate unchanged.
+    assert double_area[key]["derivative"] == pytest.approx(base_krw, rel=1e-9)
+    assert double_area[key]["derivative_total"] == pytest.approx(
+        base[key]["derivative_total"] * 2.0, rel=1e-9
+    )
+    assert double_area[node_key]["derivative"] == pytest.approx(
+        base[node_key]["derivative"], rel=1e-9
+    )
+
+
+def test_currency_and_energy_derivatives_are_distinct_and_carry_units() -> None:
+    """The kWh gradient and the ₩ gradient must not be the same number."""
+    rows = _sensitivity_rows_for(cost_per_kwh=135.0, actual_area_m2=3305.8)
+
+    kwh_row = rows[("day_heating_min_temp_C", "heating_energy_kwh_m2_day")]
+    krw_row = rows[("day_heating_min_temp_C", "heating_energy_cost_krw")]
+
+    assert kwh_row["unit"] == "kWh/m2/day/°C"
+    assert krw_row["unit"] == "KRW/m2/day/°C"
+    # ₩ = kWh x tariff. Before 2026-07-17 the "cost" derivative read the kWh field,
+    # so these two were literally the same number under different names.
+    # Tolerance is 1e-3, not tighter: each row is rounded to 6dp independently, and
+    # the kWh derivative is ~1e-3, so its rounding dominates the comparison.
+    assert krw_row["derivative"] == pytest.approx(kwh_row["derivative"] * 135.0, rel=1e-3)
+    # They must not be the same number — that was the bug.
+    assert abs(krw_row["derivative"] - kwh_row["derivative"]) > abs(kwh_row["derivative"])
+
+
+def test_node_rate_derivative_is_wired_and_has_a_unit() -> None:
+    rows = _sensitivity_rows_for(cost_per_kwh=135.0, actual_area_m2=3305.8)
+
+    for control in ("day_heating_min_temp_C", "night_heating_min_temp_C"):
+        row = rows[(control, "node_rate_day")]
+        assert row["unit"] == "node/day/°C"
+        assert isinstance(row["derivative"], float)
+
+
+def test_currency_assumptions_are_reported_with_provenance() -> None:
+    rows = _sensitivity_rows_for(cost_per_kwh=135.0, actual_area_m2=3305.8)
+    assumptions = rows["__assumptions__"]
+
+    assert assumptions["cost_per_kwh"] == 135.0
+    assert assumptions["cost_per_kwh_unit"] == "KRW/kWh"
+    assert assumptions["actual_area_m2"] == 3305.8
+    # Source must be present so a ₩120/kWh placeholder is never shown as the
+    # grower's own tariff.
+    assert "cost_per_kwh_source" in assumptions
+    assert "actual_area_m2_source" in assumptions


### PR DESCRIPTION
Closes #147

Implements Phase 0–4 of the advisor answer-quality improvement spec plus two follow-up integrations. All numeric paths are deterministic — the LLM never owns a legally- or financially-consequential number. Diagnosed via a parallel research council (artifacts local-only, gitignored).

## What changed

**Quantitative what-ifs**
- Refuse out-of-range what-ifs instead of silently answering a different question. A "+5℃?" question no longer returns the +0.9℃ result; the supported range is stated. In-range-but-unsolved deltas disclose the substitution. *(the most dangerous verified defect — it ships today)*
- Fix the ₩/℃ unit bug: the RTR sensitivity read `heating_energy_cost` (kWh/m²/day) while the real currency field `heating_energy_cost_krw` sat unused five lines away. Read the ₩ field, add night/total energy rows, attach a `unit` to every row, and project per-m² to the grower's actual area with tariff/area provenance.
- Add the node-rate derivative (day/night temperature → `node_summary.predicted_rate_day`) — the second half of "온도 1℃ 올리면 … 마디는?". Wired in RTR, not by adding a node target to `model_runtime` (whose scenario outputs carry no node state).
- `/api/rtr/sensitivity` now returns an `answer_facts` block: each ₩/node derivative is admitted and composed into a grower-facing Korean sentence ("1°C당 하루 약 573 원 (온실 전체)", validity range, provenance) or refused when `scenario_alignment` is false.
- Rename `energy_cost_72h` → `energy_load_index_72h` (dimensionless proxy, not money) with a compat alias.

**Answer admission (Phase 2)**
- Typed `AnswerFact` + admission rules (`direction_conflict`, `nonlinear`, low-confidence, missing provenance all refuse and carry no number) + deterministic composition. Chosen over OpenAI tool calling on purpose. Existence-proof test: a hostile mock model emitting 99999 cannot surface an unadmitted number.
- Fix the silent-retrieval-failure: always record a `GroundingDecision`, so a zero-evidence answer is distinguishable from a grounded one.

**Retrieval & prompt**
- Korean router: add the physiology vocabulary so naturally-phrased questions route to `crop_physiology` (was 0/4, now 4/4), and allow `markdown` sources.
- Stop the chat prompt forbidding the expert register (require units + validity range, numbers verbatim, no extrapolation) while keeping the natural-conversation UX from #145/#146.
- Widen the evidence budget (720 → up to ~7.5 KB) and stop transmitting the same excerpts twice.

**Pesticide (legal exposure)**
- Refuse PHI / safe-use numbers the local schema has no field for, pointing to RDA PSIS, before any LLM call. Route free-form pesticide chat through the deterministic `recommend_pesticides()`.
- Add a fail-closed PSIS OpenAPI gateway (`psis_gateway.py`): authoritative PHI when `PSIS_SERVICE_KEY` is set, refusal otherwise. Never guesses.

**Corpus integrity**
- Switch pypdf → pdfminer.six (MIT), which resolves the CID fonts pypdf could not (Korean guides 78% → 95% Hangul).
- Add an expected-language extraction quality gate; block promotion of a garbage index instead of shipping it silently.
- Quarantine the orphaned LLM-Wiki chunks (does **not** reintroduce #143) and the Japanese 農業技術大系 compendia, enforced in the shared retrieval filter so no caller can opt out. A real-corpus rebuild dropped corrupt prose chunks from 71.8% to 0%.

## Verification

- `poetry run pytest` — 251 passed (up from 202; the repo's editable install was also broken by an earlier OneDrive→C:\dev move and is fixed).
- `poetry run ruff check .`, `npm run lint --prefix frontend`, `npm run build --prefix frontend` — all clean.
- The council's kill-test passes: doubling the tariff exactly doubles the ₩ derivative and leaves node rate untouched; doubling area doubles the total while per-m² and node rate are unchanged; ₩ = kWh × tariff.
- Real-server API smoke: physiology question routes to `crop_physiology` with clean Korean; PHI question refused deterministically with a PSIS pointer; general chat degrades gracefully without an OpenAI key.

## Not in this PR / caveats

- **Do not merge-and-ship ₩ to growers yet**: the energy model has never been validated against measured farm data. The kill-test proves consistency, not accuracy — a field comparison is needed first.
- Cross-lingual retrieval over the Japanese compendia is out of scope, blocked on a 農文協 licensing decision; quarantine is the default.
- PSIS live lookups need a `data.go.kr` service key (documented in `.env.example`); without it the gateway correctly refuses.
- LLM answer quality itself is unverified here (no `OPENAI_API_KEY` in this environment); the deterministic paths are all tested.

Council report and full improvement spec are local-only under `docs/research/20260717-advisor-answer-quality-architecture/` (gitignored).