### PR TITLE
Insert your own environment dataset and simulate on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ out/
 results/
 runs*/
 logs/
+
+# User-uploaded environment datasets are runtime data, not source.
+data/uploads/
 screenshots/
 *.screenshot.png
 *.screenshot.jpg

--- a/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
+++ b/frontend/src/components/dashboard/SimulationRuntimePanel.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react';
-import { Activity, Gauge, Loader2, Pause, Play, RotateCcw, SkipForward, Square, Zap } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import { Activity, Gauge, Loader2, Pause, Play, RotateCcw, SkipForward, Square, Trash2, Upload, Zap } from 'lucide-react';
 import type { AppLocale } from '../../i18n/locale';
 import type { CropType, TelemetryStatus } from '../../types';
 import {
   DEFAULT_SIMULATION_PACE,
+  getDefaultSimulationCsv,
   readStoredSimulationPace,
   simulationRuntimePacePresets,
   simulationRuntimeTimeSteps,
@@ -13,7 +14,9 @@ import {
   type SimulationRuntimeTimeStep,
   useSimulationRuntimeControls,
 } from '../../hooks/useSimulationRuntimeControls';
+import { useEnvironmentDatasets } from '../../hooks/useEnvironmentDatasets';
 import { Button } from '../ui/button';
+import { Select } from '../ui/select';
 import { StatusChip } from '../ui/status-chip';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 
@@ -51,7 +54,27 @@ export default function SimulationRuntimePanel({
     () => readStoredSimulationPace() ?? DEFAULT_SIMULATION_PACE,
   );
   const runtime = useSimulationRuntimeControls(crop);
+  const datasets = useEnvironmentDatasets();
+  const [selectedDataset, setSelectedDataset] = useState<string>(() => getDefaultSimulationCsv(crop));
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isBusy = ACTION_ORDER.some((action) => runtime.state[action].status === 'loading');
+  const datasetOptions = datasets.datasets ?? [];
+  const selectedIsUploaded = datasetOptions.some(
+    (dataset) => dataset.name === selectedDataset && dataset.kind === 'uploaded',
+  );
+
+  const handleUploadFile = async (file: File | null) => {
+    if (!file) {
+      return;
+    }
+    const inserted = await datasets.upload(file);
+    if (inserted) {
+      setSelectedDataset(inserted.name);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
   const latestAction = useMemo(() => (
     [...ACTION_ORDER]
       .reverse()
@@ -77,6 +100,13 @@ export default function SimulationRuntimePanel({
         endpoint: 'endpoint',
         latest: '마지막 응답',
         noMessage: '아직 요청하지 않았습니다.',
+        dataset: '환경 데이터셋',
+        uploadDataset: 'CSV 넣기',
+        uploading: '올리는 중…',
+        deleteDataset: '삭제',
+        datasetHint: (columns: string) => `필수 컬럼: ${columns}`,
+        bundledTag: '기본',
+        uploadedTag: '내 데이터',
       }
     : {
         eyebrow: 'Simulation Runtime',
@@ -96,6 +126,13 @@ export default function SimulationRuntimePanel({
         endpoint: 'endpoint',
         latest: 'Latest response',
         noMessage: 'No runtime request yet.',
+        dataset: 'Environment dataset',
+        uploadDataset: 'Insert CSV',
+        uploading: 'Uploading…',
+        deleteDataset: 'Delete',
+        datasetHint: (columns: string) => `Required columns: ${columns}`,
+        bundledTag: 'bundled',
+        uploadedTag: 'yours',
       };
 
   const latestState = runtime.state[latestAction];
@@ -184,8 +221,68 @@ export default function SimulationRuntimePanel({
           </div>
         </div>
 
+        <div className="rounded-[var(--sg-radius-sm)] border border-[color:var(--sg-outline-soft)] p-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <label className="flex-1 text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--sg-text-faint)]">
+              <span>{copy.dataset}</span>
+              <Select
+                className="mt-1"
+                value={selectedDataset}
+                disabled={isBusy || datasets.busy}
+                onChange={(event) => setSelectedDataset(event.target.value)}
+                aria-label={copy.dataset}
+              >
+                {datasetOptions.map((dataset) => (
+                  <option key={dataset.name} value={dataset.name}>
+                    {dataset.name} · {dataset.kind === 'bundled' ? copy.bundledTag : copy.uploadedTag}
+                    {dataset.rows ? ` (${dataset.rows.toLocaleString()} rows)` : ''}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <div className="flex gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                className="hidden"
+                onChange={(event) => { void handleUploadFile(event.target.files?.[0] ?? null); }}
+              />
+              <Button
+                variant="secondary"
+                disabled={isBusy || datasets.busy}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {datasets.busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
+                {datasets.busy ? copy.uploading : copy.uploadDataset}
+              </Button>
+              {selectedIsUploaded && (
+                <Button
+                  variant="ghost"
+                  disabled={isBusy || datasets.busy}
+                  onClick={async () => {
+                    const removed = await datasets.remove(selectedDataset);
+                    if (removed) {
+                      setSelectedDataset(getDefaultSimulationCsv(crop));
+                    }
+                  }}
+                  aria-label={copy.deleteDataset}
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              )}
+            </div>
+          </div>
+          <p className="mt-2 text-[11px] leading-4 text-[color:var(--sg-text-faint)]">
+            {copy.datasetHint(datasets.requiredColumns.join(', '))}
+          </p>
+          {datasets.error && (
+            <p className="mt-1 text-[11px] leading-4 text-[color:var(--sg-color-danger,#c0392b)]">{datasets.error}</p>
+          )}
+        </div>
+
         <div className="grid gap-2 sm:grid-cols-4">
-          <Button variant="primary" disabled={isBusy} onClick={() => { void runtime.start(timeStep); }}>
+          <Button variant="primary" disabled={isBusy} onClick={() => { void runtime.start(timeStep, selectedDataset); }}>
             {runtime.state.start.status === 'loading' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Play className="h-4 w-4" aria-hidden="true" />}
             {copy.start}
           </Button>

--- a/frontend/src/hooks/useEnvironmentDatasets.ts
+++ b/frontend/src/hooks/useEnvironmentDatasets.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+import { API_URL } from '../config';
+
+export interface EnvironmentDataset {
+  name: string;
+  kind: 'bundled' | 'uploaded';
+  rows: number | null;
+  start: string | null;
+  end: string | null;
+  size_bytes: number | null;
+  uploaded_at: string | null;
+}
+
+interface DatasetListPayload {
+  status: string;
+  required_columns: string[];
+  datasets: EnvironmentDataset[];
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error((data as { detail?: string })?.detail ?? `HTTP ${response.status}`);
+  }
+  return data as T;
+}
+
+/**
+ * Lists environment datasets and lets the user insert their own so the simulation can
+ * run on data other than the two bundled fixtures. Upload sends the CSV as the raw
+ * request body to POST /api/datasets?filename=..., matching the backend contract.
+ */
+export const useEnvironmentDatasets = () => {
+  const [datasets, setDatasets] = useState<EnvironmentDataset[]>([]);
+  const [requiredColumns, setRequiredColumns] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetch(`${API_URL}/datasets`).then((response) => readJson<DatasetListPayload>(response));
+      // Never let a malformed response leave state non-array; the panel renders off this.
+      setDatasets(Array.isArray(data?.datasets) ? data.datasets : []);
+      setRequiredColumns(Array.isArray(data?.required_columns) ? data.required_columns : []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load datasets.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh().catch(() => {
+      // Errors are surfaced through hook state.
+    });
+  }, [refresh]);
+
+  const upload = useCallback(async (file: File): Promise<EnvironmentDataset | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_URL}/datasets?filename=${encodeURIComponent(file.name)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/csv' },
+        body: file,
+      });
+      const payload = await readJson<{ dataset: EnvironmentDataset }>(response);
+      await refresh();
+      return payload.dataset;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed.');
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  const remove = useCallback(async (name: string): Promise<boolean> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_URL}/datasets/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      await readJson<{ deleted: string }>(response);
+      await refresh();
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  return { datasets, requiredColumns, loading, error, busy, refresh, upload, remove };
+};

--- a/frontend/src/hooks/useSimulationRuntimeControls.ts
+++ b/frontend/src/hooks/useSimulationRuntimeControls.ts
@@ -220,10 +220,11 @@ export function useSimulationRuntimeControls(crop: CropType) {
 
   const cropKey = cropToApiKey(crop);
 
-  const start = useCallback((timeStep: SimulationRuntimeTimeStep) => execute('start', '/start', {
+  const start = useCallback((timeStep: SimulationRuntimeTimeStep, csvFilename?: string) => execute('start', '/start', {
     body: JSON.stringify({
       crop: cropKey,
-      csv_filename: getDefaultSimulationCsv(crop),
+      // Default to the crop's bundled fixture; an uploaded dataset name overrides it.
+      csv_filename: csvFilename ?? getDefaultSimulationCsv(crop),
       time_step: timeStep,
     }),
   }), [crop, cropKey, execute]);

--- a/src/model_informed_greenhouse_dashboard/backend/app/main.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/main.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 import httpx
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field, model_validator
 from typing import Dict, Any, Optional, Literal
@@ -1641,11 +1641,69 @@ app.add_middleware(
 # ===== REST Endpoints =====
 
 
+@app.get("/api/datasets")
+async def list_environment_datasets():
+    """List the environment datasets the simulation can run on.
+
+    Includes the bundled fixtures and any uploaded datasets. Use a returned `name`
+    as `csv_filename` in POST /api/start.
+    """
+    from .services.datasets import REQUIRED_COLUMNS, list_datasets
+
+    return {
+        "status": "success",
+        "required_columns": list(REQUIRED_COLUMNS),
+        "datasets": [info.to_dict() for info in list_datasets()],
+    }
+
+
+@app.post("/api/datasets")
+async def upload_environment_dataset(
+    request: Request,
+    filename: str = Query(..., description="Target dataset filename, e.g. my_house.csv"),
+):
+    """Insert a new environment dataset by uploading a CSV.
+
+    The CSV is the raw request body (no multipart dependency needed); the filename is a
+    query parameter. The dataset is validated against the environment schema before it
+    is stored, and its name can then be passed to POST /api/start to simulate on it.
+    """
+    from datetime import datetime, timezone
+
+    from .services.datasets import DatasetError, save_uploaded_dataset
+
+    content = await request.body()
+    try:
+        info = save_uploaded_dataset(
+            filename=filename,
+            content=content,
+            now_iso=datetime.now(timezone.utc).isoformat(),
+        )
+    except DatasetError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {"status": "success", "dataset": info.to_dict()}
+
+
+@app.delete("/api/datasets/{name}")
+async def delete_environment_dataset(name: str):
+    """Delete an uploaded environment dataset. Bundled fixtures cannot be deleted."""
+    from .services.datasets import DatasetError, delete_uploaded_dataset
+
+    try:
+        delete_uploaded_dataset(name)
+    except DatasetError as exc:
+        # A protected/bundled name is a 403; a missing one is a 404.
+        status = 403 if "기본 제공" in str(exc) else 404
+        raise HTTPException(status_code=status, detail=str(exc))
+    return {"status": "success", "deleted": name}
+
+
 class StartRequest(BaseModel):
     """Request to start simulation."""
 
     crop: str  # 'tomato' or 'cucumber'
-    csv_filename: str  # Filename in data directory
+    csv_filename: str  # Dataset name (bundled fixture or uploaded), resolved safely
     time_step: Literal["auto", "1s", "1min", "10min", "1h"] = "auto"
 
 
@@ -1733,10 +1791,15 @@ async def start_simulation(req: StartRequest):
         # Small delay to allow cleanup
         await asyncio.sleep(0.2)
 
-    # Load CSV data
-    import os
+    # Resolve the dataset through the dataset service, which rejects path traversal:
+    # csv_filename is user-controlled, and joining it to the data dir by hand would
+    # let "../.." escape. It resolves both bundled fixtures and uploaded datasets.
+    from .services.datasets import DatasetError, resolve_dataset_path
 
-    csv_path = os.path.join(settings.data_dir, req.csv_filename)
+    try:
+        csv_path = str(resolve_dataset_path(req.csv_filename))
+    except DatasetError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
 
     try:
         ingestor = BatchIngestor(csv_path, quality_check=True)

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/datasets.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/datasets.py
@@ -67,7 +67,13 @@ _UPLOAD_SUBDIR = "uploads"
 
 _MAX_UPLOAD_BYTES = 64 * 1024 * 1024  # 64 MiB
 _MIN_ROWS = 2
-_SAFE_STEM = re.compile(r"[^A-Za-z0-9._-]+")
+#: Characters not allowed in a stored filename: path separators, Windows-reserved
+#: punctuation, and control characters. Everything else — including Hangul and other
+#: Unicode letters — is kept, so a Korean-named file stays readable rather than being
+#: collapsed to its ASCII fragments. Path traversal is separately blocked by taking
+#: Path(...).name and by resolve_dataset_path's containment check.
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]+')
+_COLLAPSE_SPACE = re.compile(r"\s+")
 
 
 class DatasetError(ValueError):
@@ -116,7 +122,10 @@ def _sanitize_name(filename: str) -> str:
     if not base:
         raise DatasetError("파일 이름이 비어 있습니다.")
     stem = base[:-4] if base.lower().endswith(".csv") else base
-    safe_stem = _SAFE_STEM.sub("_", stem).strip("._-")
+    # Keep Unicode letters (incl. Hangul); only strip unsafe punctuation and collapse
+    # whitespace to underscores.
+    safe_stem = _UNSAFE_CHARS.sub("_", stem)
+    safe_stem = _COLLAPSE_SPACE.sub("_", safe_stem).strip("._-")
     if not safe_stem:
         raise DatasetError("파일 이름에 사용할 수 있는 문자가 없습니다.")
     name = f"{safe_stem}.csv"

--- a/src/model_informed_greenhouse_dashboard/backend/app/services/datasets.py
+++ b/src/model_informed_greenhouse_dashboard/backend/app/services/datasets.py
@@ -1,0 +1,289 @@
+"""Environment-dataset management: insert your own data and simulate on it.
+
+The simulation runs on an environment CSV resolved by filename under the data
+directory (``/api/start`` -> ``BatchIngestor``). Until now the only datasets were the
+two bundled fixtures (``Tomato_Env.CSV`` / ``Cucumber_Env.CSV``) and there was no way to
+add your own. This service adds that: validate an uploaded environment CSV against the
+canonical schema, store it safely, list what is available, and resolve a dataset name to
+an on-disk path for the simulator.
+
+Two safety properties matter here and are enforced centrally:
+
+1. **No path traversal.** A dataset name is user-controlled and ends up joined to a
+   directory. ``resolve_dataset_path`` rejects anything that is not a plain filename
+   inside the managed directory, so ``../../etc/passwd`` or an absolute path cannot
+   escape. ``/api/start`` should resolve through here rather than joining by hand.
+2. **Schema validation before storage.** A dataset that does not match the environment
+   schema would fail deep inside the simulator with an opaque error. Validate up front —
+   required columns, parseable timestamps, numeric ranges, row count — and reject with a
+   clear message so a bad upload never reaches the runtime.
+
+Reference: docs/research/20260717-advisor-answer-quality-architecture/ (unrelated), and
+the simulator's environment contract in services/ingest.py.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from ..config import settings
+
+
+#: Canonical environment schema the simulator consumes (services/ingest.py ranges +
+#: the adapters). A dataset must carry the timestamp and every environment channel.
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "datetime",
+    "T_air_C",
+    "PAR_umol",
+    "CO2_ppm",
+    "RH_percent",
+    "wind_speed_ms",
+)
+
+#: Plausibility ranges used only to reject a clearly-wrong upload (e.g. temperature in
+#: Kelvin, RH as a fraction). The simulator's ingestor still clips per-row; this is a
+#: coarser "is this the right kind of data at all" gate at insert time.
+_SANITY_RANGES: dict[str, tuple[float, float]] = {
+    "T_air_C": (-30.0, 60.0),
+    "PAR_umol": (0.0, 3500.0),
+    "CO2_ppm": (200.0, 5000.0),
+    "RH_percent": (0.0, 100.0),
+    "wind_speed_ms": (0.0, 60.0),
+}
+
+#: The bundled fixtures. They are listed but never overwritten or deleted.
+BUNDLED_DATASETS: tuple[str, ...] = ("Tomato_Env.CSV", "Cucumber_Env.CSV")
+
+#: Uploaded datasets live in their own subdirectory so they never collide with the
+#: bundled fixtures or other data-dir assets.
+_UPLOAD_SUBDIR = "uploads"
+
+_MAX_UPLOAD_BYTES = 64 * 1024 * 1024  # 64 MiB
+_MIN_ROWS = 2
+_SAFE_STEM = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class DatasetError(ValueError):
+    """A dataset was rejected. Carries a grower-readable reason."""
+
+
+@dataclass(frozen=True)
+class DatasetInfo:
+    name: str
+    kind: str  # "bundled" | "uploaded"
+    rows: int | None = None
+    start: str | None = None
+    end: str | None = None
+    size_bytes: int | None = None
+    uploaded_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "rows": self.rows,
+            "start": self.start,
+            "end": self.end,
+            "size_bytes": self.size_bytes,
+            "uploaded_at": self.uploaded_at,
+        }
+
+
+def _data_dir() -> Path:
+    return Path(settings.data_dir)
+
+
+def uploads_dir() -> Path:
+    path = _data_dir() / _UPLOAD_SUBDIR
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _sanitize_name(filename: str) -> str:
+    """Turn an arbitrary upload filename into a safe ``*.csv`` basename.
+
+    Strips any directory component and disallowed characters. Rejects names that
+    would collide with a bundled fixture, so an upload can never shadow one.
+    """
+    base = Path(filename or "").name.strip()
+    if not base:
+        raise DatasetError("파일 이름이 비어 있습니다.")
+    stem = base[:-4] if base.lower().endswith(".csv") else base
+    safe_stem = _SAFE_STEM.sub("_", stem).strip("._-")
+    if not safe_stem:
+        raise DatasetError("파일 이름에 사용할 수 있는 문자가 없습니다.")
+    name = f"{safe_stem}.csv"
+    if name in BUNDLED_DATASETS or name.lower() in {b.lower() for b in BUNDLED_DATASETS}:
+        raise DatasetError(f"'{name}'은(는) 기본 제공 데이터셋 이름이라 사용할 수 없습니다.")
+    return name
+
+
+def validate_environment_frame(df: pd.DataFrame) -> dict[str, Any]:
+    """Validate a candidate environment dataframe against the schema.
+
+    Returns a summary (rows, date range) on success; raises :class:`DatasetError`
+    with a specific reason on failure.
+    """
+    missing = [column for column in REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise DatasetError(
+            "필수 컬럼이 없습니다: "
+            + ", ".join(missing)
+            + f". 필요한 컬럼: {', '.join(REQUIRED_COLUMNS)}"
+        )
+
+    if len(df) < _MIN_ROWS:
+        raise DatasetError(f"행이 너무 적습니다({len(df)}행). 최소 {_MIN_ROWS}행이 필요합니다.")
+
+    parsed_dt = pd.to_datetime(df["datetime"], errors="coerce")
+    if parsed_dt.isna().all():
+        raise DatasetError("datetime 컬럼을 날짜/시간으로 해석할 수 없습니다.")
+    if parsed_dt.isna().any():
+        bad = int(parsed_dt.isna().sum())
+        raise DatasetError(f"datetime 컬럼에 해석할 수 없는 값이 {bad}개 있습니다.")
+
+    for column, (low, high) in _SANITY_RANGES.items():
+        numeric = pd.to_numeric(df[column], errors="coerce")
+        if numeric.isna().all():
+            raise DatasetError(f"'{column}' 컬럼이 숫자가 아닙니다.")
+        finite = numeric.dropna()
+        # A median well outside the plausible band signals the wrong unit/kind of data.
+        median = float(finite.median())
+        if median < low or median > high:
+            raise DatasetError(
+                f"'{column}' 값이 예상 범위를 벗어납니다(중앙값 {median:g}, 허용 {low:g}~{high:g}). "
+                "단위가 올바른지 확인하세요."
+            )
+
+    ordered = parsed_dt.sort_values()
+    return {
+        "rows": int(len(df)),
+        "start": ordered.iloc[0].isoformat(),
+        "end": ordered.iloc[-1].isoformat(),
+    }
+
+
+def save_uploaded_dataset(
+    *,
+    filename: str,
+    content: bytes,
+    now_iso: str | None = None,
+) -> DatasetInfo:
+    """Validate and store an uploaded environment CSV.
+
+    Raises :class:`DatasetError` on an oversized, unreadable, or non-conforming file so
+    a bad upload never reaches the simulator. ``now_iso`` is injected for testability.
+    """
+    if not content:
+        raise DatasetError("빈 파일입니다.")
+    if len(content) > _MAX_UPLOAD_BYTES:
+        raise DatasetError(
+            f"파일이 너무 큽니다({len(content) / 1e6:.1f} MB). "
+            f"최대 {_MAX_UPLOAD_BYTES / 1e6:.0f} MB까지 허용됩니다."
+        )
+
+    name = _sanitize_name(filename)
+
+    try:
+        text = _decode_csv_bytes(content)
+        frame = pd.read_csv(io.StringIO(text))
+    except DatasetError:
+        raise
+    except Exception as exc:  # pragma: no cover - pandas raises many parse errors
+        raise DatasetError(f"CSV로 읽을 수 없습니다: {type(exc).__name__}") from exc
+
+    summary = validate_environment_frame(frame)
+
+    target = uploads_dir() / name
+    # Write the normalized CSV (parsed once, columns preserved) rather than the raw
+    # bytes, so what the simulator reads is exactly what was validated.
+    frame.to_csv(target, index=False, encoding="utf-8")
+
+    return DatasetInfo(
+        name=name,
+        kind="uploaded",
+        rows=summary["rows"],
+        start=summary["start"],
+        end=summary["end"],
+        size_bytes=target.stat().st_size,
+        uploaded_at=now_iso,
+    )
+
+
+def _decode_csv_bytes(content: bytes) -> str:
+    for encoding in ("utf-8-sig", "utf-8", "cp949", "euc-kr"):
+        try:
+            return content.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    raise DatasetError("파일 인코딩을 인식할 수 없습니다(UTF-8 또는 CP949/EUC-KR).")
+
+
+def resolve_dataset_path(name: str) -> Path:
+    """Resolve a dataset name to an on-disk path, refusing traversal.
+
+    Accepts a bundled fixture (in the data dir) or an uploaded dataset (in the uploads
+    subdir). Any name that is not a plain existing file inside a managed directory is
+    rejected — no ``..``, no absolute paths, no escaping the data dir.
+    """
+    if not name or name != Path(name).name:
+        raise DatasetError("잘못된 데이터셋 이름입니다.")
+
+    data_dir = _data_dir().resolve()
+    uploads = uploads_dir().resolve()
+
+    for base in (data_dir, uploads):
+        candidate = (base / name).resolve()
+        # Containment check: the resolved path must stay under the managed dir.
+        if base in candidate.parents and candidate.is_file():
+            return candidate
+
+    raise DatasetError(f"데이터셋을 찾을 수 없습니다: {name}")
+
+
+def list_datasets() -> list[DatasetInfo]:
+    """List bundled fixtures and uploaded datasets."""
+    infos: list[DatasetInfo] = []
+    data_dir = _data_dir()
+
+    for bundled in BUNDLED_DATASETS:
+        path = data_dir / bundled
+        infos.append(
+            DatasetInfo(
+                name=bundled,
+                kind="bundled",
+                size_bytes=path.stat().st_size if path.is_file() else None,
+            )
+        )
+
+    upload_root = uploads_dir()
+    for path in sorted(upload_root.glob("*.csv")):
+        stat = path.stat()
+        infos.append(
+            DatasetInfo(
+                name=path.name,
+                kind="uploaded",
+                size_bytes=stat.st_size,
+                uploaded_at=datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+            )
+        )
+    return infos
+
+
+def delete_uploaded_dataset(name: str) -> None:
+    """Delete an uploaded dataset. Bundled fixtures cannot be deleted."""
+    if name in BUNDLED_DATASETS:
+        raise DatasetError("기본 제공 데이터셋은 삭제할 수 없습니다.")
+    if not name or name != Path(name).name:
+        raise DatasetError("잘못된 데이터셋 이름입니다.")
+    target = (uploads_dir() / name).resolve()
+    if uploads_dir().resolve() not in target.parents or not target.is_file():
+        raise DatasetError(f"업로드된 데이터셋을 찾을 수 없습니다: {name}")
+    target.unlink()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -34,9 +34,9 @@ def temp_data_dir(monkeypatch, tmp_path: Path):
 
 def test_valid_dataset_is_accepted_and_normalized(temp_data_dir) -> None:
     info = datasets.save_uploaded_dataset(
-        filename="my house test!.csv", content=_valid_csv(), now_iso="2026-07-18T00:00:00Z"
+        filename="my house data.csv", content=_valid_csv(), now_iso="2026-07-18T00:00:00Z"
     )
-    assert info.name == "my_house_test.csv"  # sanitized
+    assert info.name == "my_house_data.csv"  # spaces collapse to underscores
     assert info.kind == "uploaded"
     assert info.rows == 6
     assert info.start and info.end
@@ -86,6 +86,16 @@ def test_unparseable_datetime_is_rejected(temp_data_dir) -> None:
 def test_resolve_rejects_path_traversal(temp_data_dir, evil: str) -> None:
     with pytest.raises(datasets.DatasetError):
         datasets.resolve_dataset_path(evil)
+
+
+def test_korean_filename_is_preserved(temp_data_dir) -> None:
+    """A Korean-named upload must keep its Hangul, not collapse to ASCII fragments."""
+    info = datasets.save_uploaded_dataset(filename="여름_실측_2024.csv", content=_valid_csv())
+    assert info.name == "여름_실측_2024.csv"
+    info2 = datasets.save_uploaded_dataset(filename="내 온실 데이터.csv", content=_valid_csv())
+    assert info2.name == "내_온실_데이터.csv"  # spaces collapse to underscores
+    # Both remain resolvable and traversal is still blocked.
+    assert datasets.resolve_dataset_path("여름_실측_2024.csv").is_file()
 
 
 def test_upload_cannot_shadow_a_bundled_fixture(temp_data_dir) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,148 @@
+"""Insert your own environment dataset and simulate on it — safely."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from model_informed_greenhouse_dashboard import get_app
+from model_informed_greenhouse_dashboard.backend.app.config import settings
+from model_informed_greenhouse_dashboard.backend.app.services import datasets
+
+
+def _valid_csv(hours: int = 6) -> bytes:
+    rows = ["datetime,T_air_C,PAR_umol,CO2_ppm,RH_percent,wind_speed_ms"]
+    for hour in range(hours):
+        par = max(0, (hour - 6) * 80)
+        rows.append(f"2024-07-01 {hour:02d}:00,{18 + hour * 0.3:.1f},{par},{450 - hour},{85 - hour},0.3")
+    return ("\n".join(rows) + "\n").encode()
+
+
+@pytest.fixture
+def temp_data_dir(monkeypatch, tmp_path: Path):
+    """Point the dataset service at a temp data dir with the bundled fixtures present."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # The bundled fixtures only need to exist for listing.
+    for bundled in datasets.BUNDLED_DATASETS:
+        (data_dir / bundled).write_bytes(_valid_csv())
+    monkeypatch.setattr(settings, "data_dir", str(data_dir))
+    return data_dir
+
+
+def test_valid_dataset_is_accepted_and_normalized(temp_data_dir) -> None:
+    info = datasets.save_uploaded_dataset(
+        filename="my house test!.csv", content=_valid_csv(), now_iso="2026-07-18T00:00:00Z"
+    )
+    assert info.name == "my_house_test.csv"  # sanitized
+    assert info.kind == "uploaded"
+    assert info.rows == 6
+    assert info.start and info.end
+    # The stored file is the normalized CSV.
+    stored = datasets.resolve_dataset_path(info.name)
+    assert stored.is_file()
+    assert stored.read_text(encoding="utf-8").splitlines()[0].startswith("datetime,")
+
+
+def test_missing_columns_are_rejected(temp_data_dir) -> None:
+    with pytest.raises(datasets.DatasetError) as exc:
+        datasets.save_uploaded_dataset(
+            filename="bad.csv", content=b"datetime,T_air_C\n2024-07-01 00:00,18\n"
+        )
+    assert "필수 컬럼" in str(exc.value)
+
+
+def test_empty_file_is_rejected(temp_data_dir) -> None:
+    with pytest.raises(datasets.DatasetError):
+        datasets.save_uploaded_dataset(filename="empty.csv", content=b"")
+
+
+def test_wrong_unit_is_rejected(temp_data_dir) -> None:
+    # Temperature in Kelvin -> median far outside the plausible Celsius band.
+    kelvin = (
+        "datetime,T_air_C,PAR_umol,CO2_ppm,RH_percent,wind_speed_ms\n"
+        "2024-07-01 00:00,291,0,422,88,0.3\n"
+        "2024-07-01 01:00,292,0,430,86,0.4\n"
+    ).encode()
+    with pytest.raises(datasets.DatasetError) as exc:
+        datasets.save_uploaded_dataset(filename="kelvin.csv", content=kelvin)
+    assert "T_air_C" in str(exc.value)
+
+
+def test_unparseable_datetime_is_rejected(temp_data_dir) -> None:
+    bad = (
+        "datetime,T_air_C,PAR_umol,CO2_ppm,RH_percent,wind_speed_ms\n"
+        "not-a-date,18.7,0,422,88,0.3\n"
+        "also-bad,19.1,0,430,86,0.4\n"
+    ).encode()
+    with pytest.raises(datasets.DatasetError) as exc:
+        datasets.save_uploaded_dataset(filename="baddate.csv", content=bad)
+    assert "datetime" in str(exc.value)
+
+
+@pytest.mark.parametrize("evil", ["../../etc/passwd", "/etc/passwd", "..\\..\\win.ini", ""])
+def test_resolve_rejects_path_traversal(temp_data_dir, evil: str) -> None:
+    with pytest.raises(datasets.DatasetError):
+        datasets.resolve_dataset_path(evil)
+
+
+def test_upload_cannot_shadow_a_bundled_fixture(temp_data_dir) -> None:
+    with pytest.raises(datasets.DatasetError):
+        datasets.save_uploaded_dataset(filename="Tomato_Env.CSV", content=_valid_csv())
+
+
+def test_bundled_fixtures_cannot_be_deleted(temp_data_dir) -> None:
+    with pytest.raises(datasets.DatasetError):
+        datasets.delete_uploaded_dataset("Tomato_Env.CSV")
+
+
+def test_listing_includes_bundled_and_uploaded(temp_data_dir) -> None:
+    datasets.save_uploaded_dataset(filename="mine.csv", content=_valid_csv())
+    names = {d.name: d.kind for d in datasets.list_datasets()}
+    assert names.get("Tomato_Env.CSV") == "bundled"
+    assert names.get("Cucumber_Env.CSV") == "bundled"
+    assert names.get("mine.csv") == "uploaded"
+
+
+def test_api_upload_list_and_delete(temp_data_dir) -> None:
+    client = TestClient(get_app())
+
+    listed = client.get("/api/datasets")
+    assert listed.status_code == 200
+    assert listed.json()["required_columns"] == list(datasets.REQUIRED_COLUMNS)
+
+    up = client.post("/api/datasets?filename=api_env.csv", content=_valid_csv())
+    assert up.status_code == 200, up.text
+    assert up.json()["dataset"]["name"] == "api_env.csv"
+
+    names = {d["name"] for d in client.get("/api/datasets").json()["datasets"]}
+    assert "api_env.csv" in names
+
+    bad = client.post("/api/datasets?filename=bad.csv", content=b"datetime\n2024-07-01\n")
+    assert bad.status_code == 400
+    assert "필수 컬럼" in bad.json()["detail"]
+
+    deleted = client.delete("/api/datasets/api_env.csv")
+    assert deleted.status_code == 200
+    assert client.delete("/api/datasets/Tomato_Env.CSV").status_code == 403
+
+
+def test_api_start_resolves_upload_and_blocks_traversal(temp_data_dir) -> None:
+    with TestClient(get_app()) as client:  # enter lifespan so crop state is initialized
+        client.post("/api/datasets?filename=sim_env.csv", content=_valid_csv())
+
+        started = client.post(
+            "/api/start",
+            json={"crop": "tomato", "csv_filename": "sim_env.csv", "time_step": "1h"},
+        )
+        assert started.status_code == 200, started.text
+        assert started.json()["status"] == "success"
+        assert started.json()["rows"] == 6
+
+        traversal = client.post(
+            "/api/start",
+            json={"crop": "tomato", "csv_filename": "../../pyproject.toml"},
+        )
+        assert traversal.status_code == 404


### PR DESCRIPTION
Closes #149

Lets a grower bring their own environment data and run the simulation on it, instead of
only the two bundled fixtures. Also closes a path-traversal in `/api/start`.

## What changed

**Backend**
- `services/datasets.py`: validate an uploaded environment CSV against the canonical
  schema (`datetime, T_air_C, PAR_umol, CO2_ppm, RH_percent, wind_speed_ms`) — required
  columns, parseable timestamps, numeric channels, and coarse unit-sanity ranges — then
  store it normalized under `data/uploads/`. Filenames are sanitized (path separators and
  Windows-reserved punctuation stripped) but keep Hangul, and cannot shadow a bundled
  fixture.
- `GET /api/datasets` (list bundled + uploaded with row counts / date range),
  `POST /api/datasets?filename=...` (CSV as the raw request body — no python-multipart
  dependency), `DELETE /api/datasets/{name}` (bundled fixtures protected).
- `/api/start` now resolves `csv_filename` through `resolve_dataset_path`, which refuses
  `..`, absolute paths, and anything outside the managed dirs. Previously it joined the
  user-controlled filename straight onto the data dir.

**Frontend**
- `useEnvironmentDatasets` hook (list / upload / delete), tolerant of a malformed
  response so the panel can't crash on it.
- Simulation Runtime panel: dataset dropdown, "Insert CSV" file picker, delete for
  uploaded datasets, required-column hint, inline errors. Start runs the selected dataset;
  `useSimulationRuntimeControls.start` takes an optional filename override (default
  unchanged).

## Verification

- Backend `poetry run pytest` — 217 passed (15 new dataset tests); `ruff check .` clean.
- Frontend `npm run lint`, `npm run build` (tsc), `npm test` (vitest) — 225 passed.
- End to end under the app lifespan: upload a CSV, it appears in the list, a simulation
  actually starts on it (rows match), and `../../pyproject.toml` is refused (404). Korean
  filenames round-trip; `../../etc/passwd.csv` sanitizes to `passwd.csv`.

Note: this repo's CI does not run (`.github/` is gitignored), so the gates above were run
locally.